### PR TITLE
Mdl 25695

### DIFF
--- a/lib/weblib.php
+++ b/lib/weblib.php
@@ -1503,6 +1503,7 @@ function purify_html($text) {
         $config->set('HTML.Doctype', 'XHTML 1.0 Transitional');
         $config->set('URI.AllowedSchemes', array('http'=>true, 'https'=>true, 'ftp'=>true, 'irc'=>true, 'nntp'=>true, 'news'=>true, 'rtsp'=>true, 'teamspeak'=>true, 'gopher'=>true, 'mms'=>true));
         $config->set('Attr.AllowedFrameTargets', array('_blank'));
+        $config->set('Attr.EnableID', true);
 
         if (!empty($CFG->allowobjectembed)) {
             $config->set('HTML.SafeObject', true);


### PR DESCRIPTION
The table of contents in the wiki does not work because HTMLPurifier strips out the anchor tags. This commit tells HTMLPurifier to allow the tags, resolving the problem with the wiki toc.
