### PR TITLE
Mdl 25908

### DIFF
--- a/mod/wiki/edit.php
+++ b/mod/wiki/edit.php
@@ -45,7 +45,7 @@ $version = optional_param('version', -1, PARAM_INT);
 $attachments = optional_param('attachments', 0, PARAM_INT);
 $deleteuploads = optional_param('deleteuploads', 0, PARAM_RAW);
 
-$newconent = '';
+$newcontent = '';
 if (!empty($newcontent) && is_array($newcontent)) {
     $newcontent = $newcontent['text'];
 }


### PR DESCRIPTION
The variable newcontent is misspelled on declaration in edit.php This triggers numerous warnings when debugging is turned on but has no other downstream effects.
