### PR TITLE
MDL-3044: Fixed validation issue related to the incorrect definition of

### DIFF
--- a/backup/cc/schemas/domainProfile_1/common/dataTypes.xsd
+++ b/backup/cc/schemas/domainProfile_1/common/dataTypes.xsd
@@ -34,7 +34,7 @@
 	<!-- LanguageId -->
 	<xs:complexType name="LanguageId">
 		<xs:simpleContent>
-			<xs:extension base="xs:language">
+			<xs:extension base="xs:token">
 				<xs:attributeGroup ref="ex:customAttributes"/>
 			</xs:extension>
 		</xs:simpleContent>
@@ -66,7 +66,7 @@
 	<xs:complexType name="LangString">
 		<xs:simpleContent>
 			<xs:extension base="CharacterString">
-				<xs:attribute name="language" type="xs:language"/>
+				<xs:attribute name="language" type="xs:token"/>
 				<xs:attributeGroup ref="ex:customAttributes"/>
 			</xs:extension>
 		</xs:simpleContent>

--- a/backup/cc/schemas/domainProfile_1/dataTypes_localised.xsd
+++ b/backup/cc/schemas/domainProfile_1/dataTypes_localised.xsd
@@ -43,7 +43,7 @@
 	<!-- LanguageId -->
 	<xs:complexType name="LanguageId">
 		<xs:simpleContent>
-			<xs:extension base="xs:language">
+			<xs:extension base="xs:token">
 				<xs:attributeGroup ref="ex:customAttributes" />
 			</xs:extension>
 		</xs:simpleContent>
@@ -78,7 +78,7 @@
 	<xs:complexType name="LangString">
 		<xs:simpleContent>
 			<xs:extension base="CharacterString">
-				<xs:attribute name="language" type="xs:language" />
+				<xs:attribute name="language" type="xs:token" />
 				<xs:attributeGroup ref="ex:customAttributes" />
 			</xs:extension>
 		</xs:simpleContent>

--- a/backup/cc/schemas/domainProfile_2/common/dataTypes.xsd
+++ b/backup/cc/schemas/domainProfile_2/common/dataTypes.xsd
@@ -34,7 +34,7 @@
 	<!-- LanguageId -->
 	<xs:complexType name="LanguageId">
 		<xs:simpleContent>
-			<xs:extension base="xs:language">
+			<xs:extension base="xs:token">
 				<xs:attributeGroup ref="ex:customAttributes"/>
 			</xs:extension>
 		</xs:simpleContent>

--- a/backup/cc/schemas/domainProfile_2/dataTypes_localised.xsd
+++ b/backup/cc/schemas/domainProfile_2/dataTypes_localised.xsd
@@ -43,7 +43,7 @@
 	<!-- LanguageId -->
 	<xs:complexType name="LanguageId">
 		<xs:simpleContent>
-			<xs:extension base="xs:language">
+			<xs:extension base="xs:token">
 				<xs:attributeGroup ref="ex:customAttributes" />
 			</xs:extension>
 		</xs:simpleContent>
@@ -75,7 +75,7 @@
 	<xs:complexType name="LangString">
 		<xs:simpleContent>
 			<xs:extension base="CharacterString">
-				<xs:attribute name="language" type="xs:language" />
+				<xs:attribute name="language" type="xs:token" />
 				<xs:attributeGroup ref="ex:customAttributes" />
 			</xs:extension>
 		</xs:simpleContent>

--- a/backup/cc/schemas/domainProfile_4/ims_qtiasiv1p2_localised.xsd
+++ b/backup/cc/schemas/domainProfile_4/ims_qtiasiv1p2_localised.xsd
@@ -214,7 +214,7 @@
 				<xs:element ref="mat_extension" minOccurs="0" maxOccurs="0" />
 			</xs:choice>
 		</xs:sequence>
-		<xs:attribute name="attribute3" type="xs:language" />
+		<xs:attribute name="attribute3" type="xs:token" />
 	</xs:complexType>
 	<!-- ********* -->
 	<!-- ** and ** -->
@@ -839,7 +839,7 @@
 				<xs:attribute name="charset" type="xs:string" default="ascii-us" />
 				<xs:attribute name="uri" type="xs:string" />
 				<xs:attribute ref="xml:space" default="default" />
-				<xs:attribute name="attribute11" type="xs:language" />
+				<xs:attribute name="attribute11" type="xs:token" />
 				<xs:attribute name="entityref" type="xs:ENTITY" use="prohibited" />
 				<xs:attribute name="width" type="xs:string" />
 				<xs:attribute name="height" type="xs:string" />
@@ -869,7 +869,7 @@
 			<xs:element name="altmaterial" type="altmaterialType" minOccurs="0" maxOccurs="unbounded" />
 		</xs:sequence>
 		<xs:attribute name="label" type="string256" />
-		<xs:attribute name="attribute5" type="xs:language" />
+		<xs:attribute name="attribute5" type="xs:token" />
 	</xs:complexType>
 	<!-- ****************** -->
 	<!-- ** material_ref ** -->
@@ -912,7 +912,7 @@
 				<xs:attribute name="charset" type="xs:string" default="ascii-us" />
 				<xs:attribute name="uri" type="xs:string" />
 				<xs:attribute ref="xml:space" default="default" />
-				<xs:attribute name="attribute11" type="xs:language" />
+				<xs:attribute name="attribute11" type="xs:token" />
 				<xs:attribute name="entityref" type="xs:ENTITY" use="prohibited" />
 				<xs:attribute name="width" type="xs:string" />
 				<xs:attribute name="height" type="xs:string" />
@@ -1220,7 +1220,7 @@
 			</xs:choice>
 		</xs:sequence>
 		<xs:attribute name="label" type="xs:string" />
-		<xs:attribute name="attribute5" type="xs:language" />
+		<xs:attribute name="attribute5" type="xs:token" />
 		<xs:attribute name="y0" type="xs:string" />
 		<xs:attribute name="x0" type="xs:string" />
 		<xs:attribute name="width" type="xs:string" />
@@ -1791,7 +1791,7 @@
 		</xs:sequence>
 		<xs:attribute name="ident" type="xs:string" use="required" />
 		<xs:attribute name="title" type="xs:string" />
-		<xs:attribute name="attribute7" type="xs:language" />
+		<xs:attribute name="attribute7" type="xs:token" />
 	</xs:complexType>
 	<!-- ******************** -->
 	<!-- ** sectioncontrol ** -->

--- a/backup/cc/schemas/domainProfile_4/xml.xsd
+++ b/backup/cc/schemas/domainProfile_4/xml.xsd
@@ -102,7 +102,7 @@
          the empty string.</xs:documentation>
   </xs:annotation>
   <xs:simpleType>
-   <xs:union memberTypes="xs:language">
+   <xs:union memberTypes="xs:token">
     <xs:simpleType>    
      <xs:restriction base="xs:string">
       <xs:enumeration value="" />

--- a/backup/cc/schemas/xml.xsd
+++ b/backup/cc/schemas/xml.xsd
@@ -75,7 +75,7 @@
    </xs:documentation>
   </xs:annotation>
   <xs:simpleType>
-   <xs:union memberTypes="xs:language">
+   <xs:union memberTypes="xs:token">
     <xs:simpleType>    
      <xs:restriction base="xs:string">
       <xs:enumeration value=""/>

--- a/backup/cc/schemas11/xml.xsd
+++ b/backup/cc/schemas11/xml.xsd
@@ -102,7 +102,7 @@
          the empty string.</xs:documentation>
   </xs:annotation>
   <xs:simpleType>
-   <xs:union memberTypes="xs:language">
+   <xs:union memberTypes="xs:token">
     <xs:simpleType>    
      <xs:restriction base="xs:string">
       <xs:enumeration value="" />


### PR DESCRIPTION
xs:language type. All xs:language instances are replaced with xs:token
type. It relaxes validation enough for all the complex or dummy language
strings to be accepted.
