### PR TITLE
MDL-33757 - Sorting by email address doesn't work

### DIFF
--- a/grade/report/grader/lib.php
+++ b/grade/report/grader/lib.php
@@ -411,6 +411,9 @@ class grade_report_grader extends grade_report {
                 case 'firstname':
                     $sort = "u.firstname $this->sortorder, u.lastname $this->sortorder";
                     break;
+                case 'email':
+                    $sort = "u.email $this->sortorder";
+                    break;
                 case 'idnumber':
                 default:
                     $sort = "u.idnumber $this->sortorder";


### PR DESCRIPTION
http://tracker.moodle.org/browse/MDL-33757

Sorting by email address (click "Email address") doesn't work on any gradebook.

(1) Open any course
(2) Click "Grades"
(3) Click "Email address" to sort
