### PR TITLE
MDL-38850 Horizontal scroll bar added in Lesson

### DIFF
--- a/theme/standard/style/modules.css
+++ b/theme/standard/style/modules.css
@@ -140,6 +140,7 @@ table.mod_index {width:90%;margin:1em auto;}
 #page-mod-glossary-view .tabtree {margin-bottom: -12px;}
 
 /** Lesson **/
+.path-mod-lesson .contents {overflow-x:auto;}
 .path-mod-lesson .compacttable,
 .path-mod-lesson .standardtable,
 .path-mod-lesson .mform .box.contents {margin:1em auto;width:80%;}


### PR DESCRIPTION
Earlier, horizontal scroll bar is not present in a Lesson page where the content on that page is very wide.

Fixed

Snapshot before Patch:
![before_patch](https://f.cloud.github.com/assets/939075/411943/53416d6a-ab9a-11e2-8594-a36821c06000.png)

Snapshot after Patch:
![after_patch](https://f.cloud.github.com/assets/939075/411944/5c6e3044-ab9a-11e2-9fea-893260616058.png)
