### PR TITLE
MDL-39352 group password poilcy:fixed password policy check on group formation

### DIFF
--- a/group/group_form.php
+++ b/group/group_form.php
@@ -62,7 +62,9 @@ class group_form extends moodleform {
 
         $mform->addElement('editor', 'description_editor', get_string('groupdescription', 'group'), null, $editoroptions);
         $mform->setType('description_editor', PARAM_RAW);
-
+        if (!empty($CFG->passwordpolicy)){
+            $mform->addElement('static', 'passwordpolicyinfo', '', print_password_policy());
+        }
         $mform->addElement('passwordunmask', 'enrolmentkey', get_string('enrolmentkey', 'group'), 'maxlength="254" size="24"', get_string('enrolmentkey', 'group'));
         $mform->addHelpButton('enrolmentkey', 'enrolmentkey', 'group');
         $mform->setType('enrolmentkey', PARAM_RAW);
@@ -95,6 +97,14 @@ class group_form extends moodleform {
         $errors = parent::validation($data, $files);
 
         $name = trim($data['name']);
+
+        /*force check password_policy on time of group formation too if enrolmentkey password policy check is applied */   
+          if (!empty($CFG->groupenrolmentkeypolicy) and $data['enrolmentkey']) {
+                $errmsg = '';
+                if (!check_password_policy($data['enrolmentkey'], $errmsg)) {
+                    $errors['enrolmentkey'] = $errmsg;
+                }
+            }
         if (isset($data['idnumber'])) {
             $idnumber = trim($data['idnumber']);
         } else {
@@ -113,7 +123,7 @@ class group_form extends moodleform {
             }
 
             if (!empty($CFG->groupenrolmentkeypolicy) and $data['enrolmentkey'] != '' and $group->enrolmentkey !== $data['enrolmentkey']) {
-                // enforce password policy only if changing password
+                // enforce password policy also  if changing password
                 $errmsg = '';
                 if (!check_password_policy($data['enrolmentkey'], $errmsg)) {
                     $errors['enrolmentkey'] = $errmsg;


### PR DESCRIPTION
https://tracker.moodle.org/browse/MDL-39352?focusedCommentId=219239&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-219239

I have created a patch for this
patch file- https://github.com/RO-29/moodle/tree/MDL-39352
compare-file- https://github.com/RO-29/moodle/compare/master...MDL-39352 
although the enrolment key is complying password policy but only on the time when changing password in group settings
i have tried to fixed this issue to force check password policy on time of group formation too 
applying the patch doesn't seems to break any existing code and have tried this on MOODLE_23_STABLE, MOODLE_24_STABLE 
location for code is moodle/group/group_form.php
