### PR TITLE
Fix layout issue in theme MDL-42596

### DIFF
--- a/theme/splash/style/core.css
+++ b/theme/splash/style/core.css
@@ -509,3 +509,19 @@ strong em, em strong{
 .initialbar a {
     padding:0 2px;
 }
+
+/* fix some layout issues for Grades table */
+.generaltable img.icon {
+    height: 24px;
+}
+
+.path-grade-report-grader .left_scroller {
+    padding: 0;
+}
+#page-grade-report-grader-index #fixed_column td {
+    padding-bottom: 10px;
+}
+
+#page-grade-report-grader-index .right_scroller #user-grades td {
+    padding-bottom: 10px;
+}


### PR DESCRIPTION
The Splash Theme has some layout issues when viewing grades, details:
https://tracker.moodle.org/browse/MDL-42596

Though I could have fixed this globally, I gather nothing else is broken, so I applied the fix for Splash theme code.css only.
