### PR TITLE
MDL-43790 Date selector in self enrolment leads to unclear time definition.

### DIFF
--- a/enrol/self/edit_form.php
+++ b/enrol/self/edit_form.php
@@ -76,11 +76,11 @@ class enrol_self_edit_form extends moodleform {
         $mform->addHelpButton('expirythreshold', 'expirythreshold', 'core_enrol');
         $mform->disabledIf('expirythreshold', 'expirynotify', 'eq', 0);
 
-        $mform->addElement('date_selector', 'enrolstartdate', get_string('enrolstartdate', 'enrol_self'), array('optional' => true));
+        $mform->addElement('date_time_selector', 'enrolstartdate', get_string('enrolstartdate', 'enrol_self'), array('optional' => true));
         $mform->setDefault('enrolstartdate', 0);
         $mform->addHelpButton('enrolstartdate', 'enrolstartdate', 'enrol_self');
 
-        $mform->addElement('date_selector', 'enrolenddate', get_string('enrolenddate', 'enrol_self'), array('optional' => true));
+        $mform->addElement('date_time_selector', 'enrolenddate', get_string('enrolenddate', 'enrol_self'), array('optional' => true));
         $mform->setDefault('enrolenddate', 0);
         $mform->addHelpButton('enrolenddate', 'enrolenddate', 'enrol_self');
 


### PR DESCRIPTION
When choosing a start/end date in the self enrolment configuration it was clear at what point of time the enrolment can be done. Therefore, changed date_selector to date_time_selector in self enrolment.

```
modified:   enrol/self/edit_form.php
```
