### PR TITLE
adding fix for saving grade

### DIFF
--- a/mod/assign/locallib.php
+++ b/mod/assign/locallib.php
@@ -64,6 +64,7 @@ require_once($CFG->dirroot . '/mod/assign/renderable.php');
 require_once($CFG->dirroot . '/mod/assign/gradingtable.php');
 require_once($CFG->libdir . '/eventslib.php');
 require_once($CFG->libdir . '/portfolio/caller.php');
+require_once($CFG->dirroot . '/mod/assign/lib.php');
 
 /**
  * Standard base class for mod_assign (assignment types).


### PR DESCRIPTION
This resolves the 500 error issue experienced when trying to send grades via the api mod_assign_save_grade

This is in reference to issue [MDL-43960](https://tracker.moodle.org/browse/MDL-43960)
