### PR TITLE
fix MDL-44263

### DIFF
--- a/mod/assign/locallib.php
+++ b/mod/assign/locallib.php
@@ -30,6 +30,7 @@ defined('MOODLE_INTERNAL') || die();
 define('ASSIGN_SUBMISSION_STATUS_REOPENED', 'reopened');
 define('ASSIGN_SUBMISSION_STATUS_DRAFT', 'draft');
 define('ASSIGN_SUBMISSION_STATUS_SUBMITTED', 'submitted');
+define('ASSIGN_SUBMISSION_STATUS_NOTSUBMITTED', '');
 
 // Search filters for grading page.
 define('ASSIGN_FILTER_SUBMITTED', 'submitted');
@@ -5322,6 +5323,8 @@ class assign {
         if ($pluginerror || $allempty) {
             if ($allempty) {
                 $notices[] = get_string('submissionempty', 'mod_assign');
+                $submission->status = ASSIGN_SUBMISSION_STATUS_NOTSUBMITTED;
+                $this->update_submission($submission, $USER->id, true, $instance->teamsubmission);
             }
             return false;
         }


### PR DESCRIPTION
MDL-44263 assign: Add a submission status: ASSIGN_SUBMISSION_STATUS_NOTSUBMITTED, and modified the save_submission(), when there is no attachment than mark the submission status to ASSIGN_SUBMISSION_STATUS_NOTSUBMITTED.
