### PR TITLE
Update zip_archive.php

### DIFF
--- a/lib/filestorage/zip_archive.php
+++ b/lib/filestorage/zip_archive.php
@@ -214,7 +214,8 @@ class zip_archive extends file_archive {
             }
             return true;
         }
-
+        
+        set_time_limit(0);  // This could take some time, so make sure it doesn't timeout
         $res = $this->za->close();
         $this->za = null;
         $this->mode = null;


### PR DESCRIPTION
when creating a zip file, backup first makes the layout for the .zip in the temp directory under a long ugly folder name. This folder is used as the zip structure. During backup everything goes fine until it is time to finish the .zip file with the close() function. This function works very slowly, so if there are too many files or too big of files to process in 2 minutes it will run into the hard coded 120 second limit and time out with an error like:
PHP Fatal error: Maximum execution time of 120 seconds exceeded in \lib\filestorage
zip_archive.php on line 218
the part that times when zip_archive.php runs it's close() function. Inside this function, no progress updates are being sent out. I placed a set_time_limit(0); before the close function, and now everything works great.
