### PR TITLE
Auto-Create groups: Ignore previously grouped users

### DIFF
--- a/group/autogroup.php
+++ b/group/autogroup.php
@@ -85,7 +85,7 @@ if ($editform->is_cancelled()) {
         default:
             print_error('unknoworder');
     }
-    $users = groups_get_potential_members($data->courseid, $data->roleid, $data->cohortid, $orderby);
+    $users = groups_get_potential_members($data->courseid, $data->roleid, $data->cohortid, $orderby, !empty($data->notingroup));
     $usercnt = count($users);
 
     if ($data->allocateby == 'random') {

--- a/group/autogroup_form.php
+++ b/group/autogroup_form.php
@@ -110,6 +110,8 @@ class autogroup_form extends moodleform {
         $mform->addElement('checkbox', 'nosmallgroups', get_string('nosmallgroups', 'group'));
         $mform->disabledIf('nosmallgroups', 'groupby', 'noteq', 'members');
 
+        $mform->addElement('checkbox', 'notingroup', get_string('notingroup', 'group'));
+
         $mform->addElement('header', 'groupinghdr', get_string('grouping', 'group'));
 
         $options = array('0' => get_string('nogrouping', 'group'),

--- a/group/lib.php
+++ b/group/lib.php
@@ -709,15 +709,23 @@ function groups_get_possible_roles($context) {
  * @param int $roleid The role to select users from
  * @param int $cohortid restrict to cohort id
  * @param string $orderby The column to sort users by
+ * @param int $notingroup restrict to users not in existing groups
  * @return array An array of the users
  */
-function groups_get_potential_members($courseid, $roleid = null, $cohortid = null, $orderby = 'lastname ASC, firstname ASC') {
+function groups_get_potential_members($courseid, $roleid = null, $cohortid = null, $orderby = 'lastname ASC, firstname ASC', $notingroup = null) {
     global $DB;
 
     $context = context_course::instance($courseid);
 
     list($esql, $params) = get_enrolled_sql($context);
 
+    $notingroupsql = "";
+    if ($notingroup) {
+        // We want to eliminate users that are already associated with a course group
+        $notingroupsql = "u.id NOT IN (SELECT userid FROM {groups_members} WHERE groupid IN (SELECT id FROM {groups} WHERE courseid = :courseid))";
+        $params['courseid'] = $courseid; 
+    }
+    
     if ($roleid) {
         // We are looking for all users with this role assigned in this context or higher.
         list($relatedctxsql, $relatedctxparams) = $DB->get_in_or_equal($context->get_parent_context_ids(true), SQL_PARAMS_NAMED, 'relatedctx');
@@ -726,6 +734,9 @@ function groups_get_potential_members($courseid, $roleid = null, $cohortid = nul
         $where = "WHERE u.id IN (SELECT userid
                                    FROM {role_assignments}
                                   WHERE roleid = :roleid AND contextid $relatedctxsql)";
+        $where .= $notingroup ? "AND $notingroupsql" : "";
+    } elseif($notingroup) {
+        $where = "WHERE $notingroupsql";
     } else {
         $where = "";
     }

--- a/group/tests/behat/auto_creation.feature
+++ b/group/tests/behat/auto_creation.feature
@@ -84,3 +84,28 @@ Feature: Automatic creation of groups
     And I should see "Group B" in the ".generaltable" "css_element"
     And I should see "5" in the "Group A" "table_row"
     And I should see "5" in the "Group B" "table_row"
+
+  @javascript
+  Scenario: Split automatically the course users in groups that are not in groups
+    Given I press "Cancel"
+    And I press "Create group"
+    And I fill the moodle form with:
+      | Group name | Group 1 |
+    And I press "Save changes"
+    And I press "Create group"
+    And I fill the moodle form with:
+      | Group name | Group 2 |
+    And I press "Save changes"
+    When I add "student0" user to "Group 1" group
+    And I add "student1" user to "Group 1" group
+    And I add "student2" user to "Group 2" group
+    And I add "student3" user to "Group 2" group
+    And I press "Auto-create groups"
+    And I expand all fieldsets
+    And I set the field "Auto create based on" to "Number of groups"
+    And I set the field "Group/member count" to "2"
+    And I set the field "Grouping of auto-created groups" to "No grouping"
+    And I set the field "Ignore users in groups" to "1"
+    And I press "Submit"
+    And the "groups" select box should contain "Group A (3)"
+    And the "groups" select box should contain "Group B (3)"

--- a/lang/en/group.php
+++ b/lang/en/group.php
@@ -156,6 +156,7 @@ $string['nogroups'] = 'There are no groups set up in this course yet';
 $string['nogroupsassigned'] = 'No groups assigned';
 $string['nopermissionforcreation'] = 'Can\'t create group "{$a}" as you don\'t have the required permissions';
 $string['nosmallgroups'] = 'Prevent last small group';
+$string['notingroup'] = 'Ignore users in groups';
 $string['notingrouping'] = '[Not in a grouping]';
 $string['nousersinrole'] = 'There are no suitable users in the selected role';
 $string['number'] = 'Group/member count';


### PR DESCRIPTION
MDL-45991 groups: Auto-create groups with ungrouped users only

When using auto-create groups, sometimes it is needed to only create
groups with users that are not already inside a course group.  This
patch creates a checkbox that will ignore users that are in already
existing groups.  It alters the groups_get_potential_members function so
that the eligible users are retrieved entirely though sql.
