### PR TITLE
Adds option to the settings page so the top folder can be collapsed.

### DIFF
--- a/mod/folder/backup/moodle2/backup_folder_stepslib.php
+++ b/mod/folder/backup/moodle2/backup_folder_stepslib.php
@@ -38,7 +38,7 @@ class backup_folder_activity_structure_step extends backup_activity_structure_st
         // Define each element separated
         $folder = new backup_nested_element('folder', array('id'), array(
             'name', 'intro', 'introformat', 'revision',
-            'timemodified', 'display', 'showexpanded'));
+            'timemodified', 'display', 'showexpanded', 'showexpandedroot'));
 
         // Build the tree
         // (nice mono-tree, lol)

--- a/mod/folder/db/install.xml
+++ b/mod/folder/db/install.xml
@@ -15,6 +15,7 @@
         <FIELD NAME="timemodified" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
         <FIELD NAME="display" TYPE="int" LENGTH="4" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Display type of folder contents - on a separate page or inline"/>
         <FIELD NAME="showexpanded" TYPE="int" LENGTH="1" NOTNULL="true" UNSIGNED="false" DEFAULT="1" SEQUENCE="false" COMMENT="1 = expanded, 0 = collapsed for sub-folders"/>
+        <FIELD NAME="showexpandedroot" TYPE="int" LENGTH="1" NOTNULL="true" UNSIGNED="false" DEFAULT="1" SEQUENCE="false" COMMENT="1 = expanded, 0 = collapsed for sub-folders"/>
       </FIELDS>
       <KEYS>
         <KEY NAME="primary" TYPE="primary" FIELDS="id"/>

--- a/mod/folder/db/upgrade.php
+++ b/mod/folder/db/upgrade.php
@@ -104,6 +104,9 @@ function xmldb_folder_upgrade($oldversion) {
         if ($dbman->field_exists($table, $field)) {
             $dbman->rename_field($table, $field, 'showexpanded');
         }
+        
+		// by default after upgrade the root will be shown
+        set_config('showexpandedroot', true, 'folder');
 
         // folder savepoint reached
         upgrade_mod_savepoint(true, 2013040700, 'folder');

--- a/mod/folder/lang/en/folder.php
+++ b/mod/folder/lang/en/folder.php
@@ -52,3 +52,5 @@ $string['displayinline'] = 'Inline on a course page';
 $string['noautocompletioninline'] = 'Automatic completion on viewing of activity can not be selected together with "Display inline" option';
 $string['showexpanded'] = 'Show subfolders expanded';
 $string['showexpanded_help'] = 'If set to \'yes\', subfolders are shown expanded by default; otherwise they are shown collapsed.';
+$string['showexpandedroot'] = 'Show top folder expanded';
+$string['showexpandedroot_help'] = 'If set to \'yes\', the top root folder and its content is shown expanded by default; otherwise they are shown collapsed.';

--- a/mod/folder/lib.php
+++ b/mod/folder/lib.php
@@ -386,7 +386,7 @@ function folder_dndupload_handle($uploadinfo) {
 function folder_get_coursemodule_info($cm) {
     global $DB;
     if (!($folder = $DB->get_record('folder', array('id' => $cm->instance),
-            'id, name, display, showexpanded, intro, introformat'))) {
+            'id, name, display, showexpanded, showexpandedroot, intro, introformat'))) {
         return NULL;
     }
     $cminfo = new cached_cm_info();
@@ -395,6 +395,7 @@ function folder_get_coursemodule_info($cm) {
         // prepare folder object to store in customdata
         $fdata = new stdClass();
         $fdata->showexpanded = $folder->showexpanded;
+        $fdata->showexpandedroot = $folder->showexpandedroot;
         if ($cm->showdescription && strlen(trim($folder->intro))) {
             $fdata->intro = $folder->intro;
             if ($folder->introformat != FORMAT_MOODLE) {

--- a/mod/folder/mod_form.php
+++ b/mod/folder/mod_form.php
@@ -58,6 +58,11 @@ class mod_folder_mod_form extends moodleform_mod {
             $mform->hardFreeze('display');
         }
         $mform->setExpanded('content');
+		
+        // Adding option to show root folder expanded or collapsed.
+        $mform->addElement('advcheckbox', 'showexpandedroot', get_string('showexpandedroot', 'folder'));
+        $mform->addHelpButton('showexpandedroot', 'showexpandedroot', 'mod_folder');
+        $mform->setDefault('showexpandedroot', $config->showexpandedroot);		
 
         // Adding option to show sub-folders expanded or collapsed by default.
         $mform->addElement('advcheckbox', 'showexpanded', get_string('showexpanded', 'folder'));

--- a/mod/folder/module.js
+++ b/mod/folder/module.js
@@ -24,22 +24,24 @@
 
 M.mod_folder = {};
 
-M.mod_folder.init_tree = function(Y, id, expand_all) {
-    Y.use('yui2-treeview', function(Y) {
-        var tree = new Y.YUI2.widget.TreeView(id);
+M.mod_folder.init_tree = function(Y, id, expand_subfolders, expand_root) {
+	Y.use('yui2-treeview', function(Y) {
+		var tree = new Y.YUI2.widget.TreeView(id);
 
-        tree.subscribe("clickEvent", function(node, event) {
-            // we want normal clicking which redirects to url
-            return false;
-        });
+		tree.subscribe("clickEvent", function(node, event) {
+			// we want normal clicking which redirects to url
+			return false;
+		});
 
-        if (expand_all) {
-            tree.expandAll();
-        } else {
-            // Else just expand the top node.
-            tree.getRoot().children[0].expand();
-        }
+		if (expand_root) {
+			if (expand_subfolders) {
+				tree.expandAll();
+			} else {
+				// Else just expand the top node.
+				tree.getRoot().children[0].expand();
+			}
+		}
 
-        tree.render();
-    });
+		tree.render();
+	});
 }

--- a/mod/folder/renderer.php
+++ b/mod/folder/renderer.php
@@ -86,7 +86,11 @@ class mod_folder_renderer extends plugin_renderer_base {
         if (empty($tree->folder->showexpanded)) {
             $showexpanded = false;
         }
-        $this->page->requires->js_init_call('M.mod_folder.init_tree', array($id, $showexpanded));
+        $showexpandedroot = true;
+        if (empty($tree->folder->showexpandedroot)) {
+            $showexpandedroot = false;
+        }		
+        $this->page->requires->js_init_call('M.mod_folder.init_tree', array($id, $showexpanded, $showexpandedroot));
         return $content;
     }
 

--- a/mod/folder/settings.php
+++ b/mod/folder/settings.php
@@ -30,7 +30,11 @@ if ($ADMIN->fulltree) {
     $settings->add(new admin_setting_configcheckbox('folder/requiremodintro',
         get_string('requiremodintro', 'admin'), get_string('configrequiremodintro', 'admin'), 1));
 
-    $settings->add(new admin_setting_configcheckbox('folder/showexpanded',
+	$settings->add(new admin_setting_configcheckbox('folder/showexpandedroot',
+            get_string('showexpandedroot', 'folder'),
+            get_string('showexpandedroot_help', 'folder'), 1));
+
+	$settings->add(new admin_setting_configcheckbox('folder/showexpanded',
             get_string('showexpanded', 'folder'),
             get_string('showexpanded_help', 'folder'), 1));
 }


### PR DESCRIPTION
Till now only subfolders could be collapsed, this adds options so the top root folder can be collapsed by default as well.

This will show up in settings:
![settings](https://cloud.githubusercontent.com/assets/1096073/3400628/04a854d4-fd47-11e3-8faf-c66cbff9b6c1.png)

Normaly the root folder would be expanded by default:
![moodle](https://cloud.githubusercontent.com/assets/1096073/3400649/392da218-fd47-11e3-83fb-72606796beed.png)

With this patch it can be setup to be collapsed:
![top](https://cloud.githubusercontent.com/assets/1096073/3400657/53a09be6-fd47-11e3-8b09-33034a69d48e.png)
