### PR TITLE
MDL-38214 question - Add MCS, MCVS, MCHS Cloze subquestion types

### DIFF
--- a/question/format/xml/tests/xmlformat_test.php
+++ b/question/format/xml/tests/xmlformat_test.php
@@ -1362,7 +1362,7 @@ END;
 
         $mc->layout = 0;
         $mc->single = 1;
-        $mc->shuffleanswers = 1;
+        $mc->shuffleanswers = 0;
         $mc->correctfeedback =          array('text' => '', 'format' => FORMAT_HTML, 'itemid' => null);
         $mc->partiallycorrectfeedback = array('text' => '', 'format' => FORMAT_HTML, 'itemid' => null);
         $mc->incorrectfeedback =        array('text' => '', 'format' => FORMAT_HTML, 'itemid' => null);

--- a/question/type/multianswer/edit_multianswer_form.php
+++ b/question/type/multianswer/edit_multianswer_form.php
@@ -44,11 +44,16 @@ class qtype_multianswer_edit_form extends question_edit_form {
     // from the questiontext in database.
     public $savedquestion;
     public $savedquestiondisplay;
-    public $used_in_quiz = false;
-    public $qtype_change = false;
-    public $negative_diff = 0;
-    public $nb_of_quiz = 0;
-    public $nb_of_attempts = 0;
+    /** @var bool this question is used in quiz */
+    public $usedinquiz = false;
+    /** @var bool the qtype has been changed */
+    public $qtypechange = false;
+    /** @var integer number of questions that have been deleted   */
+    public $negativediff = 0;
+    /** @var integer number of quiz that used this question   */
+    public $nbofquiz = 0;
+    /** @var integer number of attempts that used this question   */
+    public $nbofattempts = 0;
     public $confirm = 0;
     public $reload = false;
     /** @var qtype_numerical_answer_processor used when validating numerical answers. */
@@ -60,14 +65,14 @@ class qtype_multianswer_edit_form extends question_edit_form {
         $this->regenerate = true;
         $this->reload = optional_param('reload', false, PARAM_BOOL);
 
-        $this->used_in_quiz = false;
+        $this->usedinquiz = false;
 
         if (isset($question->id) && $question->id != 0) {
             // TODO MDL-43779 should not have quiz-specific code here.
             $this->savedquestiondisplay = fullclone($question);
-            $this->nb_of_quiz = $DB->count_records('quiz_slots', array('questionid' => $question->id));
-            $this->used_in_quiz = $this->nb_of_quiz > 0;
-            $this->nb_of_attempts = $DB->count_records_sql("
+            $this->nbofquiz = $DB->count_records('quiz_slots', array('questionid' => $question->id));
+            $this->usedinquiz = $this->nbofquiz > 0;
+            $this->nbofattempts = $DB->count_records_sql("
                     SELECT count(1)
                       FROM {quiz_slots} slot
                       JOIN {quiz_attempts} quiza ON quiza.quiz = slot.quizid
@@ -151,14 +156,13 @@ class qtype_multianswer_edit_form extends question_edit_form {
                 if (isset($this->savedquestiondisplay->options->questions[$sub]->qtype) &&
                         $this->savedquestiondisplay->options->questions[$sub]->qtype !=
                                 $this->questiondisplay->options->questions[$sub]->qtype) {
-                    $this->qtype_change = true;
+                    $this->qtypechange = true;
                     $storemess = ' ' . html_writer::tag('span', get_string(
                             'storedqtype', 'qtype_multianswer', question_bank::get_qtype_name(
                                     $this->savedquestiondisplay->options->questions[$sub]->qtype)),
                             array('class' => 'error'));
                 }
-
-                $mform->addElement('header', 'subhdr'.$sub, get_string('questionno', 'question',
+                            $mform->addElement('header', 'subhdr'.$sub, get_string('questionno', 'question',
                        '{#'.$sub.'}').'&nbsp;'.question_bank::get_qtype_name(
                         $this->questiondisplay->options->questions[$sub]->qtype).$storemess);
 
@@ -183,6 +187,8 @@ class qtype_multianswer_edit_form extends question_edit_form {
                 if ($this->questiondisplay->options->questions[$sub]->qtype == 'multichoice') {
                     $mform->addElement('static', 'sub_'.$sub.'_layout',
                             get_string('layout', 'qtype_multianswer'));
+                    $mform->addElement('static', 'sub_'.$sub.'_shuffleanswers',
+                            get_string('shuffleanswers', 'qtype_multichoice'));
                 }
 
                 foreach ($this->questiondisplay->options->questions[$sub]->answer as $key => $ans) {
@@ -203,25 +209,25 @@ class qtype_multianswer_edit_form extends question_edit_form {
                 }
             }
 
-            $this->negative_diff = $countsavedsubquestions - $countsubquestions;
-            if (($this->negative_diff > 0) ||$this->qtype_change ||
-                    ($this->used_in_quiz && $this->negative_diff != 0)) {
+            $this->negativediff = $countsavedsubquestions - $countsubquestions;
+            if (($this->negativediff > 0) ||$this->qtypechange ||
+                    ($this->usedinquiz && $this->negativediff != 0)) {
                 $mform->addElement('header', 'additemhdr',
                         get_string('warningquestionmodified', 'qtype_multianswer'));
             }
-            if ($this->negative_diff > 0) {
+            if ($this->negativediff > 0) {
                 $mform->addElement('static', 'alert1', "<strong>".
                         get_string('questiondeleted', 'qtype_multianswer')."</strong>",
-                        get_string('questionsless', 'qtype_multianswer', $this->negative_diff));
+                        get_string('questionsless', 'qtype_multianswer', $this->negativediff));
             }
-            if ($this->qtype_change) {
+            if ($this->qtypechange) {
                 $mform->addElement('static', 'alert1', "<strong>".
                         get_string('questiontypechanged', 'qtype_multianswer')."</strong>",
                         get_string('questiontypechangedcomment', 'qtype_multianswer'));
             }
         }
-        if ($this->used_in_quiz) {
-            if ($this->negative_diff < 0) {
+        if ($this->usedinquiz) {
+            if ($this->negativediff < 0) {
                 $diff = $countsubquestions - $countsavedsubquestions;
                 $mform->addElement('static', 'alert1', "<strong>".
                         get_string('questionsadded', 'qtype_multianswer')."</strong>",
@@ -229,15 +235,15 @@ class qtype_multianswer_edit_form extends question_edit_form {
                         "</strong>");
             }
             $a = new stdClass();
-            $a->nb_of_quiz = $this->nb_of_quiz;
-            $a->nb_of_attempts = $this->nb_of_attempts;
+            $a->nbofquiz = $this->nbofquiz;
+            $a->nbofattempts = $this->nbofattempts;
             $mform->addElement('header', 'additemhdr2',
                     get_string('questionusedinquiz', 'qtype_multianswer', $a));
             $mform->addElement('static', 'alertas',
                     get_string('youshouldnot', 'qtype_multianswer'));
         }
-        if (($this->negative_diff > 0 || $this->used_in_quiz &&
-                ($this->negative_diff > 0 || $this->negative_diff < 0 || $this->qtype_change)) &&
+        if (($this->negativediff > 0 || $this->usedinquiz &&
+                ($this->negativediff > 0 || $this->negativediff < 0 || $this->qtypechange)) &&
                         $this->reload) {
             $mform->addElement('header', 'additemhdr',
                     get_string('questionsaveasedited', 'qtype_multianswer'));
@@ -255,7 +261,7 @@ class qtype_multianswer_edit_form extends question_edit_form {
 
     public function set_data($question) {
         global $DB;
-        $default_values = array();
+        $defaultvalues = array();
         if (isset($question->id) and $question->id and $question->qtype &&
                 $question->questiontext) {
 
@@ -282,7 +288,7 @@ class qtype_multianswer_edit_form extends question_edit_form {
                         $separator = '';
                         foreach ($wrapped->options->answers as $subanswer) {
                             $parsableanswerdef .= $separator
-                                . '%' . round(100*$subanswer->fraction) . '%';
+                                . '%' . round(100 * $subanswer->fraction) . '%';
                             if (is_array($subanswer->answer)) {
                                 $parsableanswerdef .= $subanswer->answer['text'];
                             } else {
@@ -329,39 +335,44 @@ class qtype_multianswer_edit_form extends question_edit_form {
                         if ($subquestion->qtype == 'shortanswer') {
                             switch ($subquestion->usecase) {
                                 case '1':
-                                    $default_values[$prefix.'usecase'] =
+                                    $defaultvalues[$prefix.'usecase'] =
                                             get_string('caseyes', 'qtype_shortanswer');
                                     break;
                                 case '0':
                                 default :
-                                    $default_values[$prefix.'usecase'] =
+                                    $defaultvalues[$prefix.'usecase'] =
                                             get_string('caseno', 'qtype_shortanswer');
                             }
                         }
 
                         if ($subquestion->qtype == 'multichoice') {
-                            $default_values[$prefix.'layout'] = $subquestion->layout;
+                            $defaultvalues[$prefix.'layout'] = $subquestion->layout;
                             switch ($subquestion->layout) {
                                 case '0':
-                                    $default_values[$prefix.'layout'] =
+                                    $defaultvalues[$prefix.'layout'] =
                                             get_string('layoutselectinline', 'qtype_multianswer');
                                     break;
                                 case '1':
-                                    $default_values[$prefix.'layout'] =
+                                    $defaultvalues[$prefix.'layout'] =
                                             get_string('layoutvertical', 'qtype_multianswer');
                                     break;
                                 case '2':
-                                    $default_values[$prefix.'layout'] =
+                                    $defaultvalues[$prefix.'layout'] =
                                             get_string('layouthorizontal', 'qtype_multianswer');
                                     break;
                                 default:
-                                    $default_values[$prefix.'layout'] =
+                                    $defaultvalues[$prefix.'layout'] =
                                             get_string('layoutundefined', 'qtype_multianswer');
+                            }
+                            if ($subquestion->shuffleanswers ) {
+                                $defaultvalues[$prefix.'shuffleanswers'] = get_string('yes', 'moodle');
+                            } else {
+                                $defaultvalues[$prefix.'shuffleanswers'] = get_string('no', 'moodle');
                             }
                         }
                         foreach ($subquestion->answer as $key => $answer) {
                             if ($subquestion->qtype == 'numerical' && $key == 0) {
-                                $default_values[$prefix.'tolerance['.$key.']'] =
+                                $defaultvalues[$prefix.'tolerance['.$key.']'] =
                                         $subquestion->tolerance[0];
                             }
                             if (is_array($answer)) {
@@ -384,7 +395,7 @@ class qtype_multianswer_edit_form extends question_edit_form {
                                 }
                             }
 
-                            $default_values[$prefix.'answer['.$key.']'] =
+                            $defaultvalues[$prefix.'answer['.$key.']'] =
                                     htmlspecialchars($answer);
                         }
                         if ($answercount == 0) {
@@ -402,11 +413,11 @@ class qtype_multianswer_edit_form extends question_edit_form {
                         }
                         foreach ($subquestion->feedback as $key => $answer) {
 
-                            $default_values[$prefix.'feedback['.$key.']'] =
+                            $defaultvalues[$prefix.'feedback['.$key.']'] =
                                     htmlspecialchars ($answer['text']);
                         }
                         foreach ($subquestion->fraction as $key => $answer) {
-                            $default_values[$prefix.'fraction['.$key.']'] = $answer;
+                            $defaultvalues[$prefix.'fraction['.$key.']'] = $answer;
                         }
 
                         $sub++;
@@ -414,11 +425,11 @@ class qtype_multianswer_edit_form extends question_edit_form {
                 }
             }
         }
-        $default_values['alertas']= "<strong>".get_string('questioninquiz', 'qtype_multianswer').
+        $defaultvalues['alertas'] = "<strong>".get_string('questioninquiz', 'qtype_multianswer').
                 "</strong>";
 
-        if ($default_values != "") {
-            $question = (object)((array)$question + $default_values);
+        if ($defaultvalues != "") {
+            $question = (object)((array)$question + $defaultvalues);
         }
         $question = $this->data_preprocessing_hints($question, true, true);
         parent::set_data($question);
@@ -457,9 +468,10 @@ class qtype_multianswer_edit_form extends question_edit_form {
                     if (isset($this->savedquestiondisplay->options->questions[$sub]->qtype) &&
                             $this->savedquestiondisplay->options->questions[$sub]->qtype !=
                                     $questiondisplay->options->questions[$sub]->qtype) {
-                        $storemess = " STORED QTYPE ".question_bank::get_qtype_name(
+                        $storemess += " STORED QTYPE ".question_bank::get_qtype_name(
                                 $this->savedquestiondisplay->options->questions[$sub]->qtype);
                     }
+
                     foreach ($subquestion->answer as $key => $answer) {
                         if (is_array($answer)) {
                             $answer = $answer['text'];
@@ -500,11 +512,11 @@ class qtype_multianswer_edit_form extends question_edit_form {
             }
         }
 
-        if (($this->negative_diff > 0 || $this->used_in_quiz &&
-                ($this->negative_diff > 0 || $this->negative_diff < 0 ||
-                        $this->qtype_change)) && !$this->confirm) {
+        if (($this->negativediff > 0 || $this->usedinquiz &&
+                ($this->negativediff > 0 || $this->negativediff < 0 ||
+                        $this->qtypechange)) && !$this->confirm) {
             $errors['confirm'] =
-                    get_string('confirmsave', 'qtype_multianswer', $this->negative_diff);
+                    get_string('confirmsave', 'qtype_multianswer', $this->negativediff);
         }
 
         return $errors;

--- a/question/type/multianswer/questiontype.php
+++ b/question/type/multianswer/questiontype.php
@@ -208,9 +208,15 @@ class qtype_multianswer extends question_type {
         }
 
         foreach ($questiondata->options->questions as $key => $subqdata) {
+            $answerregs = array();
+            preg_match('/'.ANSWER_REGEX.'/s', $subqdata->questiontext, $answerregs);
+            if ( $answerregs[ANSWER_REGEX_ANSWER_TYPE_MULTICHOICE] != '' ) {
+                $subqdata->options->shuffleanswers = 0;
+            }
             $subqdata->contextid = $questiondata->contextid;
-            $subqdata->options->shuffleanswers = !isset($questiondata->options->shuffleanswers) ||
-                    $questiondata->options->shuffleanswers;
+            if ( !isset($questiondata->options->shuffleanswers)||$questiondata->options->shuffleanswers == 0) {
+                $subqdata->options->shuffleanswers = 0;
+            }
             $question->subquestions[$key] = question_bank::make_question($subqdata);
             $question->subquestions[$key]->maxmark = $subqdata->defaultmark;
             if (isset($subqdata->options->layout)) {
@@ -275,7 +281,8 @@ define('NUMERICAL_ABS_ERROR_MARGIN', 6);
 // Remaining ANSWER regexes.
 define('ANSWER_TYPE_DEF_REGEX',
         '(NUMERICAL|NM)|(MULTICHOICE|MC)|(MULTICHOICE_V|MCV)|(MULTICHOICE_H|MCH)|' .
-                '(SHORTANSWER|SA|MW)|(SHORTANSWER_C|SAC|MWC)');
+        '(SHORTANSWER|SA|MW)|(SHORTANSWER_C|SAC|MWC)|' .
+        '(MULTICHOICE_S|MCS)|(MULTICHOICE_VS|MCVS)|(MULTICHOICE_HS|MCHS)');
 define('ANSWER_START_REGEX',
        '\{([0-9]*):(' . ANSWER_TYPE_DEF_REGEX . '):');
 
@@ -294,7 +301,32 @@ define('ANSWER_REGEX_ANSWER_TYPE_MULTICHOICE_REGULAR', 5);
 define('ANSWER_REGEX_ANSWER_TYPE_MULTICHOICE_HORIZONTAL', 6);
 define('ANSWER_REGEX_ANSWER_TYPE_SHORTANSWER', 7);
 define('ANSWER_REGEX_ANSWER_TYPE_SHORTANSWER_C', 8);
-define('ANSWER_REGEX_ALTERNATIVES', 9);
+define('ANSWER_REGEX_ANSWER_TYPE_MULTICHOICE_SHUFFLED', 9);
+define('ANSWER_REGEX_ANSWER_TYPE_MULTICHOICE_REGULAR_SHUFFLED', 10);
+define('ANSWER_REGEX_ANSWER_TYPE_MULTICHOICE_HORIZONTAL_SHUFFLED', 11);
+define('ANSWER_REGEX_ALTERNATIVES', 12);
+
+/**
+ * Initialise subquestion fields that are constant across all MULTICHOICE
+ * types.
+ *
+ * @param $wrapped object The subquestion to initialise
+ * @return void
+ */
+function qtype_multianswer_initialise_multichoice_subquestion($wrapped) {
+    $wrapped->qtype = 'multichoice';
+    $wrapped->single = 1;
+    $wrapped->answernumbering = 0;
+    $wrapped->correctfeedback['text'] = '';
+    $wrapped->correctfeedback['format'] = FORMAT_HTML;
+    $wrapped->correctfeedback['itemid'] = '';
+    $wrapped->partiallycorrectfeedback['text'] = '';
+    $wrapped->partiallycorrectfeedback['format'] = FORMAT_HTML;
+    $wrapped->partiallycorrectfeedback['itemid'] = '';
+    $wrapped->incorrectfeedback['text'] = '';
+    $wrapped->incorrectfeedback['format'] = FORMAT_HTML;
+    $wrapped->incorrectfeedback['itemid'] = '';
+}
 
 function qtype_multianswer_extract_question($text) {
     // Variable $text is an array [text][format][itemid].
@@ -316,7 +348,7 @@ function qtype_multianswer_extract_question($text) {
         $wrapped->generalfeedback['text'] = '';
         $wrapped->generalfeedback['format'] = FORMAT_HTML;
         $wrapped->generalfeedback['itemid'] = '';
-        if (isset($answerregs[ANSWER_REGEX_NORM])&& $answerregs[ANSWER_REGEX_NORM]!== '') {
+        if (isset($answerregs[ANSWER_REGEX_NORM]) && $answerregs[ANSWER_REGEX_NORM] !== '') {
             $wrapped->defaultmark = $answerregs[ANSWER_REGEX_NORM];
         } else {
             $wrapped->defaultmark = '1';
@@ -335,49 +367,28 @@ function qtype_multianswer_extract_question($text) {
             $wrapped->qtype = 'shortanswer';
             $wrapped->usecase = 1;
         } else if (!empty($answerregs[ANSWER_REGEX_ANSWER_TYPE_MULTICHOICE])) {
-            $wrapped->qtype = 'multichoice';
-            $wrapped->single = 1;
+            qtype_multianswer_initialise_multichoice_subquestion($wrapped);
+            $wrapped->shuffleanswers = 0;
+            $wrapped->layout = qtype_multichoice_base::LAYOUT_DROPDOWN;
+        } else if (!empty($answerregs[ANSWER_REGEX_ANSWER_TYPE_MULTICHOICE_SHUFFLED])) {
+            qtype_multianswer_initialise_multichoice_subquestion($wrapped);
             $wrapped->shuffleanswers = 1;
-            $wrapped->answernumbering = 0;
-            $wrapped->correctfeedback['text'] = '';
-            $wrapped->correctfeedback['format'] = FORMAT_HTML;
-            $wrapped->correctfeedback['itemid'] = '';
-            $wrapped->partiallycorrectfeedback['text'] = '';
-            $wrapped->partiallycorrectfeedback['format'] = FORMAT_HTML;
-            $wrapped->partiallycorrectfeedback['itemid'] = '';
-            $wrapped->incorrectfeedback['text'] = '';
-            $wrapped->incorrectfeedback['format'] = FORMAT_HTML;
-            $wrapped->incorrectfeedback['itemid'] = '';
             $wrapped->layout = qtype_multichoice_base::LAYOUT_DROPDOWN;
         } else if (!empty($answerregs[ANSWER_REGEX_ANSWER_TYPE_MULTICHOICE_REGULAR])) {
-            $wrapped->qtype = 'multichoice';
-            $wrapped->single = 1;
+            qtype_multianswer_initialise_multichoice_subquestion($wrapped);
             $wrapped->shuffleanswers = 0;
-            $wrapped->answernumbering = 0;
-            $wrapped->correctfeedback['text'] = '';
-            $wrapped->correctfeedback['format'] = FORMAT_HTML;
-            $wrapped->correctfeedback['itemid'] = '';
-            $wrapped->partiallycorrectfeedback['text'] = '';
-            $wrapped->partiallycorrectfeedback['format'] = FORMAT_HTML;
-            $wrapped->partiallycorrectfeedback['itemid'] = '';
-            $wrapped->incorrectfeedback['text'] = '';
-            $wrapped->incorrectfeedback['format'] = FORMAT_HTML;
-            $wrapped->incorrectfeedback['itemid'] = '';
+            $wrapped->layout = qtype_multichoice_base::LAYOUT_VERTICAL;
+        } else if (!empty($answerregs[ANSWER_REGEX_ANSWER_TYPE_MULTICHOICE_REGULAR_SHUFFLED])) {
+            qtype_multianswer_initialise_multichoice_subquestion($wrapped);
+            $wrapped->shuffleanswers = 1;
             $wrapped->layout = qtype_multichoice_base::LAYOUT_VERTICAL;
         } else if (!empty($answerregs[ANSWER_REGEX_ANSWER_TYPE_MULTICHOICE_HORIZONTAL])) {
-            $wrapped->qtype = 'multichoice';
-            $wrapped->single = 1;
+            qtype_multianswer_initialise_multichoice_subquestion($wrapped);
             $wrapped->shuffleanswers = 0;
-            $wrapped->answernumbering = 0;
-            $wrapped->correctfeedback['text'] = '';
-            $wrapped->correctfeedback['format'] = FORMAT_HTML;
-            $wrapped->correctfeedback['itemid'] = '';
-            $wrapped->partiallycorrectfeedback['text'] = '';
-            $wrapped->partiallycorrectfeedback['format'] = FORMAT_HTML;
-            $wrapped->partiallycorrectfeedback['itemid'] = '';
-            $wrapped->incorrectfeedback['text'] = '';
-            $wrapped->incorrectfeedback['format'] = FORMAT_HTML;
-            $wrapped->incorrectfeedback['itemid'] = '';
+            $wrapped->layout = qtype_multichoice_base::LAYOUT_HORIZONTAL;
+        } else if (!empty($answerregs[ANSWER_REGEX_ANSWER_TYPE_MULTICHOICE_HORIZONTAL_SHUFFLED])) {
+            qtype_multianswer_initialise_multichoice_subquestion($wrapped);
+            $wrapped->shuffleanswers = 1;
             $wrapped->layout = qtype_multichoice_base::LAYOUT_HORIZONTAL;
         } else {
             print_error('unknownquestiontype', 'question', '', $answerregs[2]);

--- a/question/type/multianswer/tests/helper.php
+++ b/question/type/multianswer/tests/helper.php
@@ -91,7 +91,7 @@ class qtype_multianswer_test_helper extends question_test_helper {
         $mc->generalfeedback = '';
         $mc->generalfeedbackformat = FORMAT_HTML;
 
-        $mc->shuffleanswers = 1;
+        $mc->shuffleanswers = 0;
         $mc->answernumbering = 'none';
         $mc->layout = qtype_multichoice_base::LAYOUT_DROPDOWN;
 
@@ -163,7 +163,7 @@ class qtype_multianswer_test_helper extends question_test_helper {
         $mc->options = new stdClass();
         $mc->options->layout = 0;
         $mc->options->single = 1;
-        $mc->options->shuffleanswers = 1;
+        $mc->options->shuffleanswers = 0;
         $mc->options->correctfeedback = '';
         $mc->options->correctfeedbackformat = 1;
         $mc->options->partiallycorrectfeedback = '';
@@ -227,7 +227,7 @@ class qtype_multianswer_test_helper extends question_test_helper {
         $mc->options = new stdClass();
         $mc->options->layout = 0;
         $mc->options->single = 1;
-        $mc->options->shuffleanswers = 1;
+        $mc->options->shuffleanswers = 0;
         $mc->options->correctfeedback = '';
         $mc->options->correctfeedbackformat = 1;
         $mc->options->partiallycorrectfeedback = '';
@@ -312,9 +312,8 @@ class qtype_multianswer_test_helper extends question_test_helper {
             3 => array('qt' => '{1:MULTICHOICE:=California#OK~Arizona#Wrong}', 'California' => 'OK', 'Arizona' => 'Wrong'),
             4 => array('qt' => '{1:MULTICHOICE:%0%California#Wrong~=Arizona#OK}', 'California' => 'Wrong', 'Arizona' => 'OK'),
         );
-
         foreach ($subqdata as $i => $data) {
-            // Multiple-choice subquestion.
+                // Multiple-choice subquestion.
             question_bank::load_question_definition_classes('multichoice');
             $mc = new qtype_multichoice_single_question();
             test_question_maker::initialise_a_question($mc);
@@ -333,7 +332,7 @@ class qtype_multianswer_test_helper extends question_test_helper {
                 10 * $i     => new question_answer(13, 'California', (float) ($data['California'] == 'OK'),
                         $data['California'], FORMAT_HTML),
                 10 * $i + 1 => new question_answer(14, 'Arizona', (float) ($data['Arizona'] == 'OK'),
-                        $data['Arizona'], FORMAT_HTML),
+                         $data['Arizona'], FORMAT_HTML),
             );
             $mc->qtype = question_bank::get_qtype('multichoice');
             $mc->maxmark = 1;
@@ -387,4 +386,5 @@ class qtype_multianswer_test_helper extends question_test_helper {
 
         return $q;
     }
+
 }

--- a/question/type/multianswer/tests/questiontype_test.php
+++ b/question/type/multianswer/tests/questiontype_test.php
@@ -187,4 +187,47 @@ class qtype_multianswer_test extends advanced_testcase {
             }
         }
     }
+    /**
+     *  Verify that the multiplechoice variants parameters are correctly interpreted from
+     *  the question text
+     *
+     *
+     */
+    public function test_questiontext_extraction_of_multiplechoice_subquestions_variants() {
+        $questiontext = array();
+        $questiontext['format'] = FORMAT_HTML;
+        $questiontext['itemid'] = '';
+        $questiontext['text'] = '<p>Match the following cities with the correct state:</p>
+            <ul>
+            <li>1 San Francisco:{1:MULTICHOICE:=California#OK~Arizona#Wrong}</li>
+            <li>2 Tucson:{1:MC:%0%California#Wrong~=Arizona#OK}</li>
+            <li>3 Los Angeles:{1:MULTICHOICE_S:=California#OK~Arizona#Wrong}</li>
+            <li>4 Phoenix:{1:MCS:%0%California#Wrong~=Arizona#OK}</li>
+            <li>5 San Francisco:{1:MULTICHOICE_H:=California#OK~Arizona#Wrong}</li>
+            <li>6 Tucson:{1:MCH:%0%California#Wrong~=Arizona#OK}</li>
+            <li>7 Los Angeles:{1:MULTICHOICE_HS:=California#OK~Arizona#Wrong}</li>
+            <li>8 Phoenix:{1:MCHS:%0%California#Wrong~=Arizona#OK}</li>
+            <li>9 San Francisco:{1:MULTICHOICE_V:=California#OK~Arizona#Wrong}</li>
+            <li>10 Tucson:{1:MCV:%0%California#Wrong~=Arizona#OK}</li>
+            <li>11 Los Angeles:{1:MULTICHOICE_VS:=California#OK~Arizona#Wrong}</li>
+            <li>12 Phoenix:{1:MCVS:%0%California#Wrong~=Arizona#OK}</li>
+            </ul>';
+
+        $q  = qtype_multianswer_extract_question($questiontext);
+        foreach ($q->options->questions as $key => $sub) {
+            $this->assertSame($sub->qtype , 'multichoice');
+            if ($key == 1 || $key == 2 || $key == 5 || $key == 6 || $key == 9 || $key == 10) {
+                $this->assertSame($sub->shuffleanswers , 0 );
+            } else {
+                $this->assertSame($sub->shuffleanswers , 1 );
+            }
+            if ($key == 1 || $key == 2 || $key == 3 || $key == 4) {
+                $this->assertSame($sub->layout , qtype_multichoice_base::LAYOUT_DROPDOWN );
+            } else if ($key == 5 || $key == 6 || $key == 7 || $key == 8 ) {
+                $this->assertSame($sub->layout , qtype_multichoice_base::LAYOUT_HORIZONTAL );
+            } else if ($key == 9 || $key == 10 || $key == 11 || $key == 12 ) {
+                $this->assertSame($sub->layout , qtype_multichoice_base::LAYOUT_VERTICAL );
+            }
+        }
+    }
 }


### PR DESCRIPTION
qDaniel Seemuth add MCO,MCVS,MCHS new multianswer subquestion types
qtype_multianswer_initialise_multichoice_subquestion.
Pierre Pichet MCO to MCS, add shuffling display in decode and verify edit_multianswer_form.php
add test_questiontext_extraction.

Signed-off-by: Pierre Pichet pichet.pierre@uqam.ca
