### PR TITLE
Update javascript-static.js

### DIFF
--- a/lib/javascript-static.js
+++ b/lib/javascript-static.js
@@ -249,6 +249,7 @@ M.util.show_confirm_dialog = function(e, args) {
             draggable: false,
             title: M.util.get_string('confirmation', 'admin'),
             noLabel: M.util.get_string('cancel', 'moodle'),
+            yesLabel: M.util.get_string('yes', 'moodle'),
             question: args.message
         });
 


### PR DESCRIPTION
Added yesLabel property for confirmation dialog creation, because otherwise the dialog always shows the default "Yes", no matter what language is selected.
