### PR TITLE
Div profile description

### DIFF
--- a/user/profile.php
+++ b/user/profile.php
@@ -255,9 +255,10 @@ echo '<div class="userprofilebox clearfix"><div class="profilepicture">';
 echo $OUTPUT->user_picture($user, array('size' => 100));
 echo '</div>';
 
-echo '<div class="descriptionbox"><div class="description">';
+echo '<div class="descriptionbox">';
 // Print the description.
 if ($user->description && !isset($hiddenfields['description'])) {
+    echo '<div class="description">';
     if (!empty($CFG->profilesforenrolledusersonly) && !$currentuser &&
         !$DB->record_exists('role_assignments', array('userid' => $user->id))) {
         echo get_string('profilenotshown', 'moodle');
@@ -267,8 +268,8 @@ if ($user->description && !isset($hiddenfields['description'])) {
         $options = array('overflowdiv' => true);
         echo format_text($user->description, $user->descriptionformat, $options);
     }
+    echo '</div>';
 }
-echo '</div>';
 
 
 // Print all the little details in a list.


### PR DESCRIPTION
![image-profile-with-no-description-bug](https://cloud.githubusercontent.com/assets/3605680/5503277/99c9b6da-8775-11e4-87d5-1dcaea96bb6e.jpg)

Innering the div.descriptionbox will hide the bar appearing when a description is not setted.
