### PR TITLE
MDL-50342: Convert awarding of badges to be event based.

### DIFF
--- a/badges/classes/observer.php
+++ b/badges/classes/observer.php
@@ -24,6 +24,17 @@
 
 defined('MOODLE_INTERNAL') || die();
 
+function do_review_badges_for_user($userid)
+{
+    global $CFG;
+
+    if (!empty($CFG->enablebadges)) {
+        require_once($CFG->dirroot.'/lib/badgeslib.php');
+
+        badges_review_user($userid);
+    }
+}
+
 /**
  * Event observer for badges.
  */
@@ -34,39 +45,7 @@ class core_badges_observer {
      * @param \core\event\course_module_completion_updated $event
      */
     public static function course_module_criteria_review(\core\event\course_module_completion_updated $event) {
-        global $DB, $CFG;
-
-        if (!empty($CFG->enablebadges)) {
-            require_once($CFG->dirroot.'/lib/badgeslib.php');
-
-            $eventdata = $event->get_record_snapshot('course_modules_completion', $event->objectid);
-            $userid = $event->relateduserid;
-            $mod = $event->contextinstanceid;
-
-            if ($eventdata->completionstate == COMPLETION_COMPLETE
-                || $eventdata->completionstate == COMPLETION_COMPLETE_PASS
-                || $eventdata->completionstate == COMPLETION_COMPLETE_FAIL) {
-                // Need to take into account that there can be more than one badge with the same activity in its criteria.
-                if ($rs = $DB->get_records('badge_criteria_param', array('name' => 'module_' . $mod, 'value' => $mod))) {
-                    foreach ($rs as $r) {
-                        $bid = $DB->get_field('badge_criteria', 'badgeid', array('id' => $r->critid), MUST_EXIST);
-                        $badge = new badge($bid);
-                        if (!$badge->is_active() || $badge->is_issued($userid)) {
-                            continue;
-                        }
-
-                        if ($badge->criteria[BADGE_CRITERIA_TYPE_ACTIVITY]->review($userid)) {
-                            $badge->criteria[BADGE_CRITERIA_TYPE_ACTIVITY]->mark_complete($userid);
-
-                            if ($badge->criteria[BADGE_CRITERIA_TYPE_OVERALL]->review($userid)) {
-                                $badge->criteria[BADGE_CRITERIA_TYPE_OVERALL]->mark_complete($userid);
-                                $badge->issue($userid);
-                            }
-                        }
-                    }
-                }
-            }
-        }
+        do_review_badges_for_user($event->other['relateduserid']);
     }
 
     /**
@@ -75,35 +54,7 @@ class core_badges_observer {
      * @param \core\event\course_completed $event
      */
     public static function course_criteria_review(\core\event\course_completed $event) {
-        global $DB, $CFG;
-
-        if (!empty($CFG->enablebadges)) {
-            require_once($CFG->dirroot.'/lib/badgeslib.php');
-
-            $eventdata = $event->get_record_snapshot('course_completions', $event->objectid);
-            $userid = $event->relateduserid;
-            $courseid = $event->courseid;
-
-            // Need to take into account that course can be a part of course_completion and courseset_completion criteria.
-            if ($rs = $DB->get_records('badge_criteria_param', array('name' => 'course_' . $courseid, 'value' => $courseid))) {
-                foreach ($rs as $r) {
-                    $crit = $DB->get_record('badge_criteria', array('id' => $r->critid), 'badgeid, criteriatype', MUST_EXIST);
-                    $badge = new badge($crit->badgeid);
-                    if (!$badge->is_active() || $badge->is_issued($userid)) {
-                        continue;
-                    }
-
-                    if ($badge->criteria[$crit->criteriatype]->review($userid)) {
-                        $badge->criteria[$crit->criteriatype]->mark_complete($userid);
-
-                        if ($badge->criteria[BADGE_CRITERIA_TYPE_OVERALL]->review($userid)) {
-                            $badge->criteria[BADGE_CRITERIA_TYPE_OVERALL]->mark_complete($userid);
-                            $badge->issue($userid);
-                        }
-                    }
-                }
-            }
-        }
+        do_review_badges_for_user($event->other['relateduserid']);
     }
 
     /**
@@ -112,29 +63,15 @@ class core_badges_observer {
      * @param \core\event\user_updated $event event generated when user profile is updated.
      */
     public static function profile_criteria_review(\core\event\user_updated $event) {
-        global $DB, $CFG;
+        do_review_badges_for_user($event->objectid);
+    }
 
-        if (!empty($CFG->enablebadges)) {
-            require_once($CFG->dirroot.'/lib/badgeslib.php');
-            $userid = $event->objectid;
-
-            if ($rs = $DB->get_records('badge_criteria', array('criteriatype' => BADGE_CRITERIA_TYPE_PROFILE))) {
-                foreach ($rs as $r) {
-                    $badge = new badge($r->badgeid);
-                    if (!$badge->is_active() || $badge->is_issued($userid)) {
-                        continue;
-                    }
-
-                    if ($badge->criteria[BADGE_CRITERIA_TYPE_PROFILE]->review($userid)) {
-                        $badge->criteria[BADGE_CRITERIA_TYPE_PROFILE]->mark_complete($userid);
-
-                        if ($badge->criteria[BADGE_CRITERIA_TYPE_OVERALL]->review($userid)) {
-                            $badge->criteria[BADGE_CRITERIA_TYPE_OVERALL]->mark_complete($userid);
-                            $badge->issue($userid);
-                        }
-                    }
-                }
-            }
-        }
+    /**
+     * Triggered when 'user_created' event happens.
+     *
+     * @param \core\event\user_created $event event generated when user is created.
+     */
+    public static function profile_criteria_review2(\core\event\user_created $event) {
+        do_review_badges_for_user($event->objectid);
     }
 }

--- a/badges/criteria/award_criteria_activity.php
+++ b/badges/criteria/award_criteria_activity.php
@@ -185,10 +185,6 @@ class award_criteria_activity extends award_criteria {
     public function review($userid, $filtered = false) {
         $completionstates = array(COMPLETION_COMPLETE, COMPLETION_COMPLETE_PASS);
 
-        if ($this->course->startdate > time()) {
-            return false;
-        }
-
         $info = new completion_info($this->course);
 
         $overall = false;

--- a/badges/criteria/award_criteria_course.php
+++ b/badges/criteria/award_criteria_course.php
@@ -181,10 +181,6 @@ class award_criteria_course extends award_criteria {
     public function review($userid, $filtered = false) {
         $course = $this->course;
 
-        if ($this->course->startdate > time()) {
-            return false;
-        }
-
         $info = new completion_info($course);
 
         foreach ($this->params as $param) {

--- a/badges/index.php
+++ b/badges/index.php
@@ -166,10 +166,6 @@ $records = badges_get_badges($type, $courseid, $sortby, $sorthow, $page, BADGE_P
 if ($totalcount) {
     echo $output->heading(get_string('badgestoearn', 'badges', $totalcount), 4);
 
-    if ($course && $course->startdate > time()) {
-        echo $OUTPUT->box(get_string('error:notifycoursedate', 'badges'), 'generalbox notifyproblem');
-    }
-
     if ($err !== '') {
         echo $OUTPUT->notification($err, 'notifyproblem');
     }

--- a/lib/db/events.php
+++ b/lib/db/events.php
@@ -53,6 +53,10 @@ $observers = array(
     array(
         'eventname'   => '\core\event\user_updated',
         'callback'    => 'core_badges_observer::profile_criteria_review',
+    ),
+    array(
+        'eventname'   => '\core\event\user_created',
+        'callback'    => 'core_badges_observer::profile_criteria_review2',
     )
 
 );


### PR DESCRIPTION
This patch switches Moodle's issuing of badges from being cron based to event
based. This avoids unnecessary and inefficient checking and rechecking of
criteria that haven't yet been fulfilled when nothing has changed since the
last cron run.

The patch has been made as simple as possible. It checks the criteria for all
unissued badges for a user when an event occurs that could result in criteria
being fulfilled. Further optimisations could potentially provide the ability to
just check the criteria (if any) related to the event.

This version of the patch will allow a badge to be issued prior to the start
date for a course. It could be modified further so that Moodle didn't display
the badge or send a notification until the start date, but I've left that
out for now.

Signed-off-by: Nigel Cunningham <nigelc@catalyst-au.net>