### PR TITLE
Update index.php

### DIFF
--- a/blog/index.php
+++ b/blog/index.php
@@ -140,7 +140,7 @@ if (!empty($modid)) {
     $courseid = $mod->course;
 }
 
-if ((empty($courseid) ? true : $courseid == SITEID) && empty($userid)) {
+if ((empty($courseid) ? true : $courseid == SITEID) && !isset($userid)) {
     if ($CFG->bloglevel < BLOG_SITE_LEVEL) {
         print_error('siteblogdisable', 'blog');
     }


### PR DESCRIPTION
Users start with 0 and "empty" returns true if the argument=0. So guests can't see admin's blog records regardless security policy and blog settings.