### PR TITLE
Do not make category total visible unexpectedly

### DIFF
--- a/grade/edit/tree/lib.php
+++ b/grade/edit/tree/lib.php
@@ -191,7 +191,7 @@ class grade_edit_tree {
             $item = $category->get_grade_item();
 
             // Add aggregation coef input if not a course item and if parent category has correct aggregation type
-            $dimmed = ($item->is_hidden()) ? 'dimmed_text' : '';
+            $dimmed = ($category->is_hidden()) ? 'dimmed_text' : '';
 
             // Before we print the category's row, we must find out how many rows will appear below it (for the filler cell's rowspan)
             $aggregation_position = grade_get_setting($COURSE->id, 'aggregationposition', $CFG->grade_aggregationposition);

--- a/lib/grade/grade_category.php
+++ b/lib/grade/grade_category.php
@@ -2468,7 +2468,11 @@ class grade_category extends grade_object {
     public function set_hidden($hidden, $cascade=false) {
         $this->load_grade_item();
         //this hides the associated grade item (the course total)
-        $this->grade_item->set_hidden($hidden, $cascade);
+        if ($hidden != 0 || $cascade) {
+            //Always hide category total when hiding category. Only show category
+            //total when explicitly cascading.
+            $this->grade_item->set_hidden($hidden, $cascade);
+        }
         //this hides the category itself and everything it contains
         parent::set_hidden($hidden, $cascade);
 

--- a/lib/grade/grade_item.php
+++ b/lib/grade/grade_item.php
@@ -623,9 +623,12 @@ class grade_item extends grade_object {
 
         //if marking item visible make sure category is visible MDL-21367
         if( !$hidden ) {
-            $category_array = grade_category::fetch_all(array('id'=>$this->categoryid));
-            if ($category_array && array_key_exists($this->categoryid, $category_array)) {
-                $category = $category_array[$this->categoryid];
+            //If the categoryid is null, this is a category grade item. The categoryid
+            //is stored in iteminstance.
+            $categoryid = $this->categoryid ? $this->categoryid : $this->iteminstance; 
+            $category_array = grade_category::fetch_all(array('id'=>$categoryid));
+            if ($category_array && array_key_exists($categoryid, $category_array)) {
+                $category = $category_array[$categoryid];
                 //call set_hidden on the category regardless of whether it is hidden as its parent might be hidden
                 //if($category->is_hidden()) {
                     $category->set_hidden($hidden, false);


### PR DESCRIPTION
This pull request addresses MDL-46978. Specifically, when showing a grade item in a hidden category, after applying this patch, the category total will not also be made visible.