### PR TITLE
allow import of password-protected calendars

### DIFF
--- a/lib/moodlelib.php
+++ b/lib/moodlelib.php
@@ -1017,7 +1017,7 @@ function clean_param($param, $type) {
         case PARAM_URL:          // Allow safe ftp, http, mailto urls.
             $param = fix_utf8($param);
             include_once($CFG->dirroot . '/lib/validateurlsyntax.php');
-            if (!empty($param) && validateUrlSyntax($param, 's?H?S?F?E?u-P-a?I?p?f?q?r?')) {
+            if (!empty($param) && validateUrlSyntax($param, 's?H?S?F?E?u?P?a?I?p?f?q?r?')) {
                 // All is ok, param is respected.
             } else {
                 // Not really ok.


### PR DESCRIPTION
Calendar subscriptions of password-protected calendars are not possible as of 2015-11-23. This is due to URLs of the form user:password@example.com/myCalendar.ics being rejected as invalid. If these were accepted, which the proposed change makes sure, subscribing to pw-protected calendars would be possible. As curl can already handle such URLs, no further changes are required.

Downside: I do not know what other parts of Moodle would be affected in what ways by this change (to a very central function).