### PR TITLE
Allow UNC path to access moodledata

### DIFF
--- a/lib/moodlelib.php
+++ b/lib/moodlelib.php
@@ -8328,13 +8328,16 @@ function mtrace($string, $eol="\n", $sleep=0) {
 }
 
 /**
- * Replace 1 or more slashes or backslashes to 1 slash
+ * Replace 1 or more slashes or backslashes to 1 slash except both ones if present (to allow UNC path)
  *
  * @param string $path The path to strip
  * @return string the path with double slashes removed
  */
 function cleardoubleslashes ($path) {
-    return preg_replace('/(\/|\\\){1,}/', '/', $path);
+    if (strlen($path) > 2 && (substr($path, 0, 2) == "\\\\" || substr($path, 0, 2) == "//"))
+        return substr($path, 0, 2).preg_replace('/(\/|\\\){1,}/', '/', substr($path, 2));
+    else
+        return preg_replace('/(\/|\\\){1,}/', '/', $path);
 }
 
 /**


### PR DESCRIPTION
Resolve a bug during installation when moodledata is accessed via a UNC path (ex : file cluster into windows environnement)
This bug affect all Moodle versions (see https://tracker.moodle.org/browse/MDL-38858)