### PR TITLE
MDL-38858 Allow UNC path for moodledata directory

### DIFF
--- a/lib/moodlelib.php
+++ b/lib/moodlelib.php
@@ -8425,7 +8425,12 @@ function mtrace($string, $eol="\n", $sleep=0) {
  * @return string the path with double slashes removed
  */
 function cleardoubleslashes ($path) {
-    return preg_replace('/(\/|\\\){1,}/', '/', $path);
+    if (strlen($path) > 2 && (substr($path, 0, 2) == "\\\\" || substr($path, 0, 2) == "//")) {
+        return substr($path, 0, 2).preg_replace('/(\/|\\\){1,}/', '/', substr($path, 2));
+    }
+    else {
+        return preg_replace('/(\/|\\\){1,}/', '/', $path);
+    }
 }
 
 /**


### PR DESCRIPTION
This fix resolve an error while installing or upgrading Moodle when using a UNC path for the moodledata directory on Windows Server.