### PR TITLE
MDL-54841 Combine 2 separated links for attachment

### DIFF
--- a/mod/workshop/renderer.php
+++ b/mod/workshop/renderer.php
@@ -877,7 +877,7 @@ class mod_workshop_renderer extends plugin_renderer_base {
             $type       = $file->get_mimetype();
             $image      = $this->output->pix_icon(file_file_icon($file), get_mimetype_description($file), 'moodle', array('class' => 'icon'));
 
-            $linkhtml   = html_writer::link($fileurl, $image) . substr($filepath, 1) . html_writer::link($fileurl, $filename);
+            $linkhtml   = html_writer::link($fileurl, $image . substr($filepath, 1) . $filename);
             $linktxt    = "$filename [$fileurl]";
 
             if ($format == 'html') {


### PR DESCRIPTION
MDL-54841 
Accessibility enhancements: Combine 2 separated links for attachment icon and text

On the view submission page where having attachment, there're 2 separate links for the icon and text which causes an issue for keyboard and screen reader users.
So the text and icon should be combined in the one link.