### PR TITLE
Expose external authentication methods in login block

### DIFF
--- a/blocks/login/block_login.php
+++ b/blocks/login/block_login.php
@@ -32,7 +32,7 @@ class block_login extends block_base {
     }
 
     function get_content () {
-        global $USER, $CFG, $SESSION;
+        global $USER, $CFG, $SESSION, $OUTPUT;
         $wwwroot = '';
         $signup = '';
 
@@ -94,6 +94,24 @@ class block_login extends block_base {
             $this->content->text .= '<div class="c1 btn"><input type="submit" value="'.get_string('login').'" /></div>';
 
             $this->content->text .= "</form>\n";
+
+            $authsequence = get_enabled_auth_plugins(true); // auths, in sequence
+            $potentialidps = array();
+            foreach($authsequence as $authname) {
+                $authplugin = get_auth_plugin($authname);
+                $potentialidps = array_merge($potentialidps, $authplugin->loginpage_idp_list($SESSION->wantsurl));
+            }
+
+            if (!empty($potentialidps)) {
+                $this->content->text .= '<div class="potentialidps">';
+                $this->content->text .= '<h6>' . get_string('potentialidps', 'auth') . '</h6>';
+                $this->content->text .= '<div class="potentialidplist">';
+                foreach ($potentialidps as $idp) {
+                    $this->content->text .= '<div class="potentialidp"><a href="' . $idp['url']->out() . '" title="' . $idp['name'] . '">' . $OUTPUT->render($idp['icon'], $idp['name']) . $idp['name'] . '</a></div>';
+                }
+                $this->content->text .= '</div>';
+                $this->content->text .= '</div>';
+            }
 
             if (!empty($signup)) {
                 $this->content->footer .= '<div><a href="'.$signup.'">'.get_string('startsignup').'</a></div>';


### PR DESCRIPTION
*** PLEASE DO NOT OPEN PULL REQUESTS VIA GITHUB ***

The moodle.git repository at Github is just a mirror of the official repository. We do not accept pull requests at Github.

See CONTRIBUTING.txt guidelines for how to contribute patches for Moodle. Thank you.

--

Unlike the login page, login block currently does not list any configured external auth methods. This makes it practically useless in cases where external auth (e.g. OpenID) is the main login method.

This patch adds the necessary bits to make the login block great again.

The reason why I'm not filing this via Jira is because it won't allow me to:

![create_moodle_issue](https://cloud.githubusercontent.com/assets/2812673/18677041/44ac8ff8-7f60-11e6-86e7-10b4a956427a.PNG)

Jira implies that this issue has already been filed and suggests that I vote on it instead, yet, I couldn't find it there.