### PR TITLE
Fixing search when rating enabled

### DIFF
--- a/mod/glossary/sql.php
+++ b/mod/glossary/sql.php
@@ -78,6 +78,11 @@ switch ($tab) {
             case 'search':
                 list($allentries, $count) = glossary_get_entries_by_search($glossary, $context, $hook, $fullsearch,
                     $sortkey, $sortorder, $offset, $entriesbypage);
+
+                // Scripts like view.php expect $allentries to be an array, not a recordset.
+                $aux = iterator_to_array($allentries, true);
+                $allentries->close();
+                $allentries = $aux;
                 break;
 
             case 'term':


### PR DESCRIPTION
Core change which looks like it could be patched (from bug tracker https://tracker.moodle.org/browse/MDL-55808?jql=text%20~%20%22glossary%20ratings%22)

For the glossary mod
When rating is enabled, it broke the search function

This code fixed that, so search still works when rating is enabled for the glossary.

