### PR TITLE
require_once statements removed from calendar/lib.php

### DIFF
--- a/calendar/lib.php
+++ b/calendar/lib.php
@@ -2139,7 +2139,7 @@ class calendar_event {
     protected function get_description() {
         global $CFG;
 
-        require_once($CFG->libdir . '/filelib.php');
+        
 
         if ($this->_description === null) {
             // Check if we have already resolved the context for this event
@@ -3127,8 +3127,7 @@ function calendar_delete_subscription($subscription) {
 function calendar_get_icalendar($url) {
     global $CFG;
 
-    require_once($CFG->libdir.'/filelib.php');
-
+    
     $curl = new curl();
     $curl->setopt(array('CURLOPT_FOLLOWLOCATION' => 1, 'CURLOPT_MAXREDIRS' => 5));
     $calendar = $curl->get($url);
@@ -3305,7 +3304,7 @@ function calendar_cron() {
     global $CFG, $DB;
 
     // In order to execute this we need bennu.
-    require_once($CFG->libdir.'/bennu/bennu.inc.php');
+    
 
     mtrace('Updating calendar subscriptions:');
     cron_trace_time_and_memory();


### PR DESCRIPTION
*** PLEASE DO NOT OPEN PULL REQUESTS VIA GITHUB ***

The moodle.git repository at Github is just a mirror of the official repository. We do not accept pull requests at Github.

See CONTRIBUTING.txt guidelines for how to contribute patches for Moodle. Thank you.

--
