### PR TITLE
Update gradelib.php

### DIFF
--- a/lib/gradelib.php
+++ b/lib/gradelib.php
@@ -880,7 +880,7 @@ function grade_format_gradevalue_letter($value, $grade_item) {
             // The boundary is a percentage out of 100 so use 0 as the min and 100 as the max.
             $boundary = grade_grade::standardise_score($boundary, 0, 100, 0, 100);
         }
-        if ($value >= $boundary) {
+        if (($value > $boundary) || (abs($value - $boundary) < 0.00001)) {
             return format_string($letter);
         }
     }


### PR DESCRIPTION
It's nor correct to compare two floats with == operator, the right way is to use this construction (abs($value - $boundary) < 0.00001), i had some problems when was using my grade scale ( five points = 91%), i had 91% grade in my quiz and in the grade report i saw four points instead of five point (5 = 91%, 4 = 81%, 3 = 71%, 2 = 0%).
Official documentation about it in http://php.net/manual/en/language.types.float.php

*** PLEASE DO NOT OPEN PULL REQUESTS VIA GITHUB ***

The moodle.git repository at Github is just a mirror of the official repository. We do not accept pull requests at Github.

See CONTRIBUTING.txt guidelines for how to contribute patches for Moodle. Thank you.

--
