### PR TITLE
+recovergrades to ws: enrol_manual_enrol_users

### DIFF
--- a/enrol/manual/externallib.php
+++ b/enrol/manual/externallib.php
@@ -58,7 +58,8 @@ class enrol_manual_external extends external_api {
                                         'courseid' => new external_value(PARAM_INT, 'The course to enrol the user role in'),
                                         'timestart' => new external_value(PARAM_INT, 'Timestamp when the enrolment start', VALUE_OPTIONAL),
                                         'timeend' => new external_value(PARAM_INT, 'Timestamp when the enrolment end', VALUE_OPTIONAL),
-                                        'suspend' => new external_value(PARAM_INT, 'set to 1 to suspend the enrolment', VALUE_OPTIONAL)
+                                        'suspend' => new external_value(PARAM_BOOL, 'set to 1 to suspend the enrolment', VALUE_OPTIONAL),
+                                        'recovergrades' => new external_value(PARAM_BOOL, 'set to 1 to recover grades', VALUE_OPTIONAL)
                                     )
                             )
                     )
@@ -139,7 +140,7 @@ class enrol_manual_external extends external_api {
                     ENROL_USER_SUSPENDED : ENROL_USER_ACTIVE;
 
             $enrol->enrol_user($instance, $enrolment['userid'], $enrolment['roleid'],
-                    $enrolment['timestart'], $enrolment['timeend'], $enrolment['status']);
+                    $enrolment['timestart'], $enrolment['timeend'], $enrolment['status'], $enrolment['recovergrades']);
 
         }
 


### PR DESCRIPTION
this adds enrolments[n][recovergrades] (as a boolean) - also changes SUSPEND to a boolean (as it should be)

By adding recovergrades - webservices can now re-enrol a student back into a course with grade-recovery

*** PLEASE DO NOT OPEN PULL REQUESTS VIA GITHUB ***

The moodle.git repository at Github is just a mirror of the official repository. We do not accept pull requests at Github.

See CONTRIBUTING.txt guidelines for how to contribute patches for Moodle. Thank you.

--
