### PR TITLE
mysqli is not supported with PHP 7

### DIFF
--- a/enrol/database/lib.php
+++ b/enrol/database/lib.php
@@ -850,7 +850,7 @@ class enrol_database_plugin extends enrol_plugin {
         require_once($CFG->libdir.'/adodb/adodb.inc.php');
 
         // Connect to the external database (forcing new connection).
-        $extdb = ADONewConnection($this->get_config('dbtype'));
+        $extdb = ADONewConnection($CFG->dbtype);
         if ($this->get_config('debugdb')) {
             $extdb->debug = true;
             ob_start(); // Start output buffer to allow later use of the page headers.


### PR DESCRIPTION
Full discussion: https://moodle.org/mod/forum/discuss.php?d=346581#p1452410

A number of Moodlers moving to Moodle 3.x on PHP7 have run in to this problem.

MySQLi driver file doesn't load at all, falling back to MySQL.

On PHP7 servers this leads to Moodle completely breaking.

For whatever reason, this $extdb = ADONewConnection($this->get_config('dbtype')); output is 'mysql', even though my configuration is set to 'mysqli'.

So, can we not pull this straight from the $CFG? It has fixed my issue on production.

*** PLEASE DO NOT OPEN PULL REQUESTS VIA GITHUB ***

The moodle.git repository at Github is just a mirror of the official repository. We do not accept pull requests at Github.

See CONTRIBUTING.txt guidelines for how to contribute patches for Moodle. Thank you.

--
