### PR TITLE
Basic docker-compose file for local development

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+version: "3"
+services:
+  web:
+    image: jhardison/moodle
+    ports:
+      - 8080:80
+    volumes:
+      - ./:/var/www/html
+      - moodle_data:/var/moodledata
+    environment:
+      - "MOODLE_URL:http://localhost:8080"
+  mysql:
+    image: mysql:5
+    environment:
+      - MYSQL_DATABASE=moodle
+      - MYSQL_ROOT_PASSWORD=moodle
+      - MYSQL_USER=moodle
+      - MYSQL_PASSWORD=moodle
+volumes:
+  moodle_data:


### PR DESCRIPTION
This is a simple docker-compose file that should allow anybody with `docker` and `docker-compose` to get started with local development.

I have set everything up to use the `jhardison/moodle` image which seems to work but is not perfect (no cron-job for example), however it should suffice for now.

I will write up some more detailed instructions when everybody is happy that this works to a reasonable degree but here are the basic steps:
* clone down the repo
* run `docker-compose up`
* navigate to `localhost:8080` and run through the installation instructions
* when prompted to enter the data directory choose `/var/moodledata`
* when prompted to enter the mysql details enter `mysql` as the host and `moodle` for basically everything else