### PR TITLE
Moodle Database plugin - Improve search

### DIFF
--- a/mod/data/field/text/field.class.php
+++ b/mod/data/field/text/field.class.php
@@ -52,7 +52,7 @@ class data_field_text extends data_field_base {
         static $i=0;
         $i++;
         $name = "df_text_$i";
-        return array(" ({$tablealias}.fieldid = {$this->field->id} AND ".$DB->sql_like("{$tablealias}.content", ":$name", false).") ", array($name=>"%$value%"));
+        return array(" ({$tablealias}.fieldid = {$this->field->id} AND ".$DB->sql_like("{$tablealias}.content", ":$name", false).") ", array($name=>"%".implode('%', explode(' ', $value))."%"));
     }
 
     /**

--- a/mod/data/field/textarea/field.class.php
+++ b/mod/data/field/textarea/field.class.php
@@ -189,7 +189,7 @@ class data_field_textarea extends data_field_base {
         static $i=0;
         $i++;
         $name = "df_textarea_$i";
-        return array(" ({$tablealias}.fieldid = {$this->field->id} AND ".$DB->sql_like("{$tablealias}.content", ":$name", false).") ", array($name=>"%$value%"));
+        return array(" ({$tablealias}.fieldid = {$this->field->id} AND ".$DB->sql_like("{$tablealias}.content", ":$name", false).") ", array($name=>"%".implode('%', explode(' ', $value))."%"));
     }
 
     function print_after_form() {

--- a/mod/data/locallib.php
+++ b/mod/data/locallib.php
@@ -1156,7 +1156,7 @@ function data_search_entries($data, $cm, $context, $mode, $currentgroup, $search
             $searchselect = " AND (".$DB->sql_like('c.content', ':search1', false)."
                               OR ".$DB->sql_like('u.firstname', ':search2', false)."
                               OR ".$DB->sql_like('u.lastname', ':search3', false)." ) ";
-            $params['search1'] = "%$search%";
+            $params['search1'] = "%".implode('%', explode(' ', $search))."%";
             $params['search2'] = "%$search%";
             $params['search3'] = "%$search%";
         } else {
@@ -1195,7 +1195,7 @@ function data_search_entries($data, $cm, $context, $mode, $currentgroup, $search
             $searchselect = " AND (".$DB->sql_like('c.content', ':search1', false)." OR
                 ".$DB->sql_like('u.firstname', ':search2', false)." OR
                 ".$DB->sql_like('u.lastname', ':search3', false)." ) ";
-            $params['search1'] = "%$search%";
+            $params['search1'] = "%".implode('%', explode(' ', $search))."%";
             $params['search2'] = "%$search%";
             $params['search3'] = "%$search%";
         } else {


### PR DESCRIPTION
Moodle database plugin doesn't support search multiple words. It looks for entire phrase. This is a small code change to implement capability to search multiple words. This little change make this database plugin more user friendly.
