### PR TITLE
MDL-63928

### DIFF
--- a/pix/e/insert_edit_video.svg
+++ b/pix/e/insert_edit_video.svg
@@ -1,13 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 21.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 16 16" style="enable-background:new 0 0 16 16;" xml:space="preserve" preserveAspectRatio="xMinYMid meet">
-<style type="text/css">
-	.st0{fill:#999999;}
-</style>
-<path class="st0" d="M14.9,4.9v10.3c0,0.5-0.4,0.9-0.9,0.9H2c-0.4-0.1-0.8-0.5-0.8-1V0.9C1.2,0.4,1.6,0,2.1,0l0,0h8
-	c0.5,0,1.1,0.2,1.5,0.6l2.8,2.8C14.6,3.8,14.9,4.3,14.9,4.9z M13.8,5.7H10c-0.5,0-0.9-0.4-0.9-0.8V1.1H2.2v13.7h11.4L13.8,5.7z
-	 M9.1,8v3.4c0,0.6-0.5,1.1-1.1,1.1H4.6c-0.6,0-1.1-0.5-1.1-1.1V8c0-0.6,0.5-1.1,1.1-1.1H8C8.6,6.9,9.1,7.4,9.1,8z M12.5,7.1v5.1
-	c0,0.1-0.1,0.2-0.2,0.3h-0.1c-0.1,0-0.2,0-0.2-0.1L9.6,10V9.3L12,6.9c0.1-0.1,0.1-0.1,0.2-0.1h0.1C12.5,6.9,12.5,7,12.5,7.1z
-	 M10.2,4.6h3.4c0-0.1-0.1-0.3-0.2-0.4l-2.8-2.8c-0.1-0.1-0.2-0.1-0.4-0.2C10.2,1.2,10.2,4.6,10.2,4.6z"/>
-</svg>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" [
+	<!ENTITY ns_flows "http://ns.adobe.com/Flows/1.0/">
+]><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" preserveAspectRatio="xMinYMid meet" overflow="visible"><path class="st0" d="M14.9,4.9v10.3c0,0.5-0.4,0.9-0.9,0.9H2c-0.4-0.1-0.8-0.5-0.8-1V0.9C1.2,0.4,1.6,0,2.1,0l0,0h8c0.5,0,1.1,0.2,1.5,0.6l2.8,2.8C14.6,3.8,14.9,4.3,14.9,4.9z M13.8,5.7H10c-0.5,0-0.9-0.4-0.9-0.8V1.1H2.2v13.7h11.4L13.8,5.7zM9.1,8v3.4c0,0.6-0.5,1.1-1.1,1.1H4.6c-0.6,0-1.1-0.5-1.1-1.1V8c0-0.6,0.5-1.1,1.1-1.1H8C8.6,6.9,9.1,7.4,9.1,8z M12.5,7.1v5.1c0,0.1-0.1,0.2-0.2,0.3h-0.1c-0.1,0-0.2,0-0.2-0.1L9.6,10V9.3L12,6.9c0.1-0.1,0.1-0.1,0.2-0.1h0.1C12.5,6.9,12.5,7,12.5,7.1zM10.2,4.6h3.4c0-0.1-0.1-0.3-0.2-0.4l-2.8-2.8c-0.1-0.1-0.2-0.1-0.4-0.2C10.2,1.2,10.2,4.6,10.2,4.6z" fill="#999"/></svg>


### PR DESCRIPTION
When customizing an individual Moodle theme, it has been noticed that the insert_edit_video icon is not included correctly. The corresponding svg file must be adapted to moodle standards. The error occurs only in the Activity Forum.

*** PLEASE DO NOT OPEN PULL REQUESTS VIA GITHUB ***

The moodle.git repository at Github is just a mirror of the official repository. We do not accept pull requests at Github.

See CONTRIBUTING.txt guidelines for how to contribute patches for Moodle. Thank you.

--
