### PR TITLE
Fixed MDL-63959 for nested dependencies.

### DIFF
--- a/mod/feedback/classes/completion.php
+++ b/mod/feedback/classes/completion.php
@@ -165,7 +165,7 @@ class mod_feedback_completion extends mod_feedback_structure {
             $value = $this->get_values_tmp($ditem);
         }
         if ($value === null) {
-            return null;
+            return false;
         }
         return $itemobj->compare_value($ditem, $value, $item->dependvalue) ? true : false;
     }


### PR DESCRIPTION
For example the dependecy chain is the following: A->B->C
When a question (A) depends on another dependent item (B) and B hasn't
displayed (because of C's response), the $value for the B's response will be
null. In this case the can_see_item() method returned null.
Because the can_see_item() returned null (not false),
the get_pages() method displayed the question A,
because it checks for explicit false: $this->can_see_item($item) !== false

*** PLEASE DO NOT OPEN PULL REQUESTS VIA GITHUB ***

The moodle.git repository at Github is just a mirror of the official repository. We do not accept pull requests at Github.

See CONTRIBUTING.txt guidelines for how to contribute patches for Moodle. Thank you.

--
