### PR TITLE
add amr type

### DIFF
--- a/lib/classes/filetypes.php
+++ b/lib/classes/filetypes.php
@@ -57,6 +57,8 @@ abstract class core_filetypes {
             'aif' => array('type' => 'audio/x-aiff', 'icon' => 'audio', 'groups' => array('audio'), 'string' => 'audio'),
             'aiff' => array('type' => 'audio/x-aiff', 'icon' => 'audio', 'groups' => array('audio'), 'string' => 'audio'),
             'aifc' => array('type' => 'audio/x-aiff', 'icon' => 'audio', 'groups' => array('audio'), 'string' => 'audio'),
+            'amr' => array('type' => 'audio/amr', 'icon' => 'amr', 'groups' => array('audio', 'html_audio', 'web_audio'),
+                    'string' => 'audio'),
             'applescript' => array('type' => 'text/plain', 'icon' => 'text'),
             'asc' => array('type' => 'text/plain', 'icon' => 'sourcecode'),
             'asm' => array('type' => 'text/plain', 'icon' => 'sourcecode'),


### PR DESCRIPTION
When you record a speech on an android smartphone, it makes '.amr' format... Could you add it on default mime type please?

*** PLEASE DO NOT OPEN PULL REQUESTS VIA GITHUB ***

The moodle.git repository at Github is just a mirror of the official repository. We do not accept pull requests at Github.

See CONTRIBUTING.txt guidelines for how to contribute patches for Moodle. Thank you.

--
