### PR TITLE
MDL-19711 dml: Enable use of readonly slave database handles

### DIFF
--- a/config-dist.php
+++ b/config-dist.php
@@ -79,6 +79,29 @@ $CFG->dboptions = array(
                                 // set to zero if you are using pg_bouncer in
                                 // 'transaction' mode (it is fine in 'session'
                                 // mode).
+    // 'connecttimeout' => null, // Set connect timeout in seconds. Not all drivers support it.
+    // 'readonly' => [      // Set to read-only slave details, to get safe reads
+                            // from there instead of the master node.
+                            // Needs a db driver that supports the feature.
+        // 'instance' => [
+            // [
+                // 'dbhost' => 'slave.db',
+                // 'dbport' => '',         \\ Defaults to master port
+                // 'dbuser' => '',         \\ Defaults to master user
+                // 'dbpass' => '',         \\ Defaults to master password
+            // ],
+            // [...],
+        // ],
+    // Instance(s) can alternatively be specified as:
+        // 'instance' => 'slave.db',
+        // 'instance' => ['slave.db1', 'slave.db2'],
+        // 'instance' => ['dbhost' => 'slave.db', 'dbport' => '', 'dbuser' => '', 'dbpass' => ''],
+        //
+        // 'connecttimeout' => 2, // Set read-only slave connect timeout in seconds. See above.
+        // 'latency' => 0.5,      // Set read-only slave sync latency, delay
+                                  // after update when it is deemed safe to read from the dbhost_readonly.
+        // 'exclude_tables' => ['table1', 'table2'], // Tables to exclude from read-only slave feature.
+    // ]
 );
 
 

--- a/lib/dml/moodle_database.php
+++ b/lib/dml/moodle_database.php
@@ -108,13 +108,13 @@ abstract class moodle_database {
     /** @var float Last time in seconds with millisecond precision. */
     protected $last_time;
     /** @var bool Flag indicating logging of query in progress. This helps prevent infinite loops. */
-    private $loggingquery = false;
+    protected $loggingquery = false;
 
     /** @var bool True if the db is used for db sessions. */
     protected $used_for_db_sessions = false;
 
     /** @var array Array containing open transactions. */
-    private $transactions = array();
+    protected $transactions = array();
     /** @var bool Flag used to force rollback of all current transactions. */
     private $force_rollback = false;
 
@@ -2678,6 +2678,22 @@ abstract class moodle_database {
      */
     public function perf_get_reads() {
         return $this->reads;
+    }
+
+    /**
+     * Returns whether we want to connect to slave database for read queries.
+     * @return bool Want read only connection
+     */
+    public function want_read_slave() {
+        return false;
+    }
+
+    /**
+     * Returns the number of reads before first write done by this database.
+     * @return int Number of reads.
+     */
+    public function perf_get_reads_slave() {
+        return 0;
     }
 
     /**

--- a/lib/dml/moodle_read_slave_trait.php
+++ b/lib/dml/moodle_read_slave_trait.php
@@ -1,0 +1,290 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Trait that adds read-only slave connection capability
+ *
+ * @package    core
+ * @category   dml
+ * @copyright  2018 Srdjan Janković, Catalyst IT
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+trait moodle_read_slave_trait {
+
+    /** @var resource master write database handle */
+    protected $dbhwrite;
+
+    /** @var resource slave read only database handle */
+    protected $dbhreadonly;
+
+    private $wantreadslave = false;
+    private $readsslave = 0;
+    private $slavelatency = 0;
+
+    private $written = [];
+    private $readexclude = [];
+
+    private $pdbhost;
+    private $pdbuser;
+    private $pdbpass;
+    private $pdbname;
+    private $pprefix;
+    private $pdboptions;
+
+    /**
+     * Gets db handle currently used with queries
+     * @return resource
+     */
+    abstract protected function db_handle();
+
+    /**
+     * Sets db handle to be used with subsequent queries
+     * @param resource $dbh
+     * @return void
+     */
+    abstract protected function set_db_handle($dbh);
+
+    /**
+     * Connect to db
+     * @param string $dbhost The database host.
+     * @param string $dbuser The database username.
+     * @param string $dbpass The database username's password.
+     * @param string $dbname The name of the database being connected to.
+     * @param mixed $prefix string means moodle db prefix, false used for external databases where prefix not used
+     * @param array $dboptions driver specific options
+     * @return bool true
+     * @throws dml_connection_exception if error
+     */
+    abstract protected function _connect($dbhost, $dbuser, $dbpass, $dbname, $prefix, array $dboptions=null);
+
+    /**
+     * Connect to db
+     * Must be called before other methods.
+     * @param string $dbhost The database host.
+     * @param string $dbuser The database username.
+     * @param string $dbpass The database username's password.
+     * @param string $dbname The name of the database being connected to.
+     * @param mixed $prefix string means moodle db prefix, false used for external databases where prefix not used
+     * @param array $dboptions driver specific options
+     * @return bool true
+     * @throws dml_connection_exception if error
+     */
+    public function connect($dbhost, $dbuser, $dbpass, $dbname, $prefix, array $dboptions=null) {
+        $this->pdbhost = $dbhost;
+        $this->pdbuser = $dbuser;
+        $this->pdbpass = $dbpass;
+        $this->pdbname = $dbname;
+        $this->pprefix = $prefix;
+        $this->pdboptions = $dboptions;
+
+        if ($dboptions) {
+            if (isset($dboptions['readonly'])) {
+                $this->wantreadslave = true;
+                $dboptionsro = $dboptions['readonly'];
+
+                if (isset($dboptionsro['connecttimeout'])) {
+                    $dboptions['connecttimeout'] = $dboptionsro['connecttimeout'];
+                } else if (!isset($dboptions['connecttimeout'])) {
+                    $dboptions['connecttimeout'] = 2; // Default readonly connection timeout.
+                }
+                if (isset($dboptionsro['latency'])) {
+                    $this->slavelatency = $dboptionsro['latency'];
+                }
+                if (isset($dboptionsro['exclude_tables'])) {
+                    $this->readexclude = $dboptionsro['exclude_tables'];
+                    if (!is_array($this->readexclude)) {
+                        throw new configuration_exception('exclude_tables must be an array');
+                    }
+                }
+                $dbport = isset($dboptions['dbport']) ? $dboptions['dbport'] : null;
+
+                $ro = $dboptionsro['instance'];
+                if (!is_array($ro) || !isset($ro[0])) {
+                    $ro = [$ro];
+                }
+                foreach ($ro as $ro1) {
+                    if (!is_array($ro1)) {
+                        $ro1 = ['dbhost' => $ro1];
+                    }
+                    foreach (['dbhost', 'dbuser', 'dbpass'] as $v) {
+                        $vro = "${v}ro";
+                        $$vro = isset($ro1[$v]) ? $ro1[$v] : $$v;
+                    }
+                    $dboptions['dbport'] = isset($ro1['dbport']) ? $ro1['dbport'] : $dbport;
+
+                    // @codingStandardsIgnoreStart
+                    try {
+                        $this->_connect($dbhostro, $dbuserro, $dbpassro, $dbname, $prefix, $dboptions);
+                        $this->dbhreadonly = $this->db_handle();
+                        break;
+                    } catch (dml_connection_exception $e) {
+                        // If readonly slave is not connectable we'll have to do without it.
+                    }
+                    // @codingStandardsIgnoreEnd
+                }
+            }
+        }
+        if (!$this->dbhreadonly) {
+            $this->set_dbhwrite();
+        }
+
+        return true;
+    }
+
+    /**
+     * Set database handle to readwrite master
+     * Will connect if required. Calls set_db_handle()
+     * @return void
+     */
+    private function set_dbhwrite() {
+        // Late connect to read/write master if needed.
+        if (!$this->dbhwrite) {
+            $this->_connect($this->pdbhost, $this->pdbuser, $this->pdbpass, $this->pdbname, $this->pprefix, $this->pdboptions);
+            $this->dbhwrite = $this->db_handle();
+        }
+        $this->set_db_handle($this->dbhwrite);
+    }
+
+    /**
+     * Returns whether we want to connect to slave database for read queries.
+     * @return bool Want read only connection
+     */
+    public function want_read_slave() {
+        return $this->wantreadslave;
+    }
+
+    /**
+     * Returns the number of reads done by the read only database.
+     * @return int Number of reads.
+     */
+    public function perf_get_reads_slave() {
+        return $this->readsslave;
+    }
+
+    /**
+     * On DBs that support it, switch to transaction mode and begin a transaction
+     * @return moodle_transaction
+     */
+    public function start_delegated_transaction() {
+        $this->set_dbhwrite();
+        return parent::start_delegated_transaction();
+    }
+
+    /**
+     * Called before each db query.
+     * @param string $sql
+     * @param array $params array of parameters
+     * @param int $type type of query
+     * @param mixed $extrainfo driver specific extra information
+     * @return void
+     */
+    protected function query_start($sql, array $params=null, $type, $extrainfo=null) {
+        parent::query_start($sql, $params, $type, $extrainfo);
+        $this->select_db_handle($type, $sql);
+    }
+
+    /**
+     * Select appropriate db handle - readwrite or readonly
+     * @param int $type type of query
+     * @param string $sql
+     * @return void
+     */
+    protected function select_db_handle($type, $sql) {
+        if ($this->dbhreadonly && $this->_query_is_ro($type, $sql)) {
+                $this->readsslave++;
+                $this->set_db_handle($this->dbhreadonly);
+                return;
+        }
+        $this->set_dbhwrite();
+    }
+
+    /**
+     * Check if The query qualifies for readonly connection execution
+     * @param int $type type of query
+     * @param string $sql
+     * @return bool
+     */
+    private function _query_is_ro($type, $sql) {
+        if ($this->transactions) {
+            return false;
+        }
+
+        if ($this->loggingquery) {
+            return false;
+        }
+
+        // ... lock_db queries always go to master.
+        if (preg_match('/lock_db\b/', $sql)) {
+            return false;
+        }
+
+        // Transactions are done as AUX, we cannot play with that.
+        switch ($type) {
+            case SQL_QUERY_SELECT:
+                $now = null;
+                foreach ($this->table_names($sql) as $t) {
+                    if (in_array($t, $this->readexclude)) {
+                        return false;
+                    }
+
+                    if ($this->temptables && $this->temptables->is_temptable($t)) {
+                        return false;
+                    }
+
+                    if (isset($this->written[$t])) {
+                        if ($this->slavelatency) {
+                            $now = $now ?: microtime(true);
+                            if ($now - $this->written[$t] < $this->slavelatency) {
+                                return false;
+                            }
+                        } else {
+                            return false;
+                        }
+                    }
+                }
+
+                return true;
+            case SQL_QUERY_INSERT:
+            case SQL_QUERY_UPDATE:
+                $now = $this->slavelatency ? microtime(true) : true;
+                foreach ($this->table_names($sql) as $t) {
+                    $this->written[$t] = $now;
+                }
+                return false;
+            case SQL_QUERY_STRUCTURE:
+                foreach ($this->table_names($sql) as $t) {
+                    if (!in_array($t, $this->readexclude)) {
+                        $this->readexclude[] = $t;
+                    }
+                }
+                return false;
+        }
+        return false;
+    }
+
+    /**
+     * Parse table names from query
+     * @param string $sql
+     * @return array
+     */
+    protected function table_names($sql) {
+        preg_match_all('/\b'.$this->prefix.'([a-z][A-Za-z0-9_]*)/', $sql, $match);
+        return $match[1];
+    }
+}

--- a/lib/dml/mysqli_native_moodle_database.php
+++ b/lib/dml/mysqli_native_moodle_database.php
@@ -25,6 +25,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 require_once(__DIR__.'/moodle_database.php');
+require_once(__DIR__.'/moodle_read_slave_trait.php');
 require_once(__DIR__.'/mysqli_native_moodle_recordset.php');
 require_once(__DIR__.'/mysqli_native_moodle_temptables.php');
 
@@ -36,6 +37,7 @@ require_once(__DIR__.'/mysqli_native_moodle_temptables.php');
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class mysqli_native_moodle_database extends moodle_database {
+    use moodle_read_slave_trait;
 
     /** @var mysqli $mysqli */
     protected $mysqli = null;
@@ -148,6 +150,24 @@ class mysqli_native_moodle_database extends moodle_database {
     }
 
     /**
+     * Gets db handle currently used with queries
+     * @return resource
+     */
+    protected function db_handle() {
+        return $this->mysqli;
+    }
+
+    /**
+     * Sets db handle to be used with subsequent queries
+     * @param resource $dbh
+     * @return void
+     */
+    protected function set_db_handle($dbh) {
+        $this->mysqli = $dbh;
+    }
+
+
+    /**
      * Returns the current MySQL db engine.
      *
      * This is an ugly workaround for MySQL default engine problems,
@@ -235,6 +255,14 @@ class mysqli_native_moodle_database extends moodle_database {
         if (isset($this->dboptions['dbcollation'])) {
             return $this->dboptions['dbcollation'];
         }
+    }
+
+    /**
+     * Set 'dbcollation' option
+     *
+     * @return string $dbcollation
+     */
+    private function _set_dbcollation() {
         if ($this->external) {
             return null;
         }
@@ -246,9 +274,7 @@ class mysqli_native_moodle_database extends moodle_database {
         $sql = "SELECT collation_name
                   FROM INFORMATION_SCHEMA.COLUMNS
                  WHERE table_schema = DATABASE() AND table_name = '{$this->prefix}config' AND column_name = 'value'";
-        $this->query_start($sql, NULL, SQL_QUERY_AUX);
         $result = $this->mysqli->query($sql);
-        $this->query_end($result);
         if ($rec = $result->fetch_assoc()) {
             // MySQL 8 BC: information_schema.* returns the fields in upper case.
             $rec = array_change_key_case($rec, CASE_LOWER);
@@ -260,9 +286,7 @@ class mysqli_native_moodle_database extends moodle_database {
         if (!$collation) {
             // Get the default database collation, but only if using UTF-8.
             $sql = "SELECT @@collation_database";
-            $this->query_start($sql, NULL, SQL_QUERY_AUX);
             $result = $this->mysqli->query($sql);
-            $this->query_end($result);
             if ($rec = $result->fetch_assoc()) {
                 if (strpos($rec['@@collation_database'], 'utf8_') === 0 || strpos($rec['@@collation_database'], 'utf8mb4_') === 0) {
                     $collation = $rec['@@collation_database'];
@@ -275,9 +299,7 @@ class mysqli_native_moodle_database extends moodle_database {
             // We want only utf8 compatible collations.
             $collation = null;
             $sql = "SHOW COLLATION WHERE Collation LIKE 'utf8mb4\_%' AND Charset = 'utf8mb4'";
-            $this->query_start($sql, NULL, SQL_QUERY_AUX);
             $result = $this->mysqli->query($sql);
-            $this->query_end($result);
             while ($res = $result->fetch_assoc()) {
                 $collation = $res['Collation'];
                 if (strtoupper($res['Default']) === 'YES') {
@@ -518,7 +540,6 @@ class mysqli_native_moodle_database extends moodle_database {
 
     /**
      * Connect to db
-     * Must be called before other methods.
      * @param string $dbhost The database host.
      * @param string $dbuser The database username.
      * @param string $dbpass The database username's password.
@@ -527,7 +548,7 @@ class mysqli_native_moodle_database extends moodle_database {
      * @param array $dboptions driver specific options
      * @return bool success
      */
-    public function connect($dbhost, $dbuser, $dbpass, $dbname, $prefix, array $dboptions=null) {
+    public function _connect($dbhost, $dbuser, $dbpass, $dbname, $prefix, array $dboptions=null) {
         $driverstatus = $this->driver_installed();
 
         if ($driverstatus !== true) {
@@ -556,9 +577,12 @@ class mysqli_native_moodle_database extends moodle_database {
         if ($dbhost and !empty($this->dboptions['dbpersist'])) {
             $dbhost = "p:$dbhost";
         }
-        $this->mysqli = @new mysqli($dbhost, $dbuser, $dbpass, $dbname, $dbport, $dbsocket);
+        $this->mysqli = mysqli_init();
+        if (!empty($this->dboptions['connecttimeout'])) {
+            $this->mysqli->options(MYSQLI_OPT_CONNECT_TIMEOUT, $this->dboptions['connecttimeout']);
+        }
 
-        if ($this->mysqli->connect_errno !== 0) {
+        if (!$this->mysqli->real_connect($dbhost, $dbuser, $dbpass, $dbname, $dbport, $dbsocket)) {
             $dberr = $this->mysqli->connect_error;
             $this->mysqli = null;
             throw new dml_connection_exception($dberr);
@@ -568,16 +592,14 @@ class mysqli_native_moodle_database extends moodle_database {
         $this->query_log_prevent();
 
         if (isset($dboptions['dbcollation'])) {
-            $collationinfo = explode('_', $dboptions['dbcollation']);
-            $this->dboptions['dbcollation'] = $dboptions['dbcollation'];
+            $collation = $this->dboptions['dbcollation'] = $dboptions['dbcollation'];
         } else {
-            $collationinfo = explode('_', $this->get_dbcollation());
+            $collation = $this->_set_dbcollation();
         }
+        $collationinfo = explode('_', $collation);
         $charset = reset($collationinfo);
 
-        $this->query_start("--set_charset()", null, SQL_QUERY_AUX);
         $this->mysqli->set_charset($charset);
-        $this->query_end(true);
 
         // If available, enforce strict mode for the session. That guaranties
         // standard behaviour under some situations, avoiding some MySQL nasty
@@ -587,9 +609,7 @@ class mysqli_native_moodle_database extends moodle_database {
         $si = $this->get_server_info();
         if (version_compare($si['version'], '5.0.2', '>=')) {
             $sql = "SET SESSION sql_mode = 'STRICT_ALL_TABLES'";
-            $this->query_start($sql, null, SQL_QUERY_AUX);
             $result = $this->mysqli->query($sql);
-            $this->query_end($result);
         }
 
         // We can enable logging now.

--- a/lib/dml/pgsql_native_moodle_database.php
+++ b/lib/dml/pgsql_native_moodle_database.php
@@ -25,6 +25,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 require_once(__DIR__.'/moodle_database.php');
+require_once(__DIR__.'/moodle_read_slave_trait.php');
 require_once(__DIR__.'/pgsql_native_moodle_recordset.php');
 require_once(__DIR__.'/pgsql_native_moodle_temptables.php');
 
@@ -36,6 +37,10 @@ require_once(__DIR__.'/pgsql_native_moodle_temptables.php');
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class pgsql_native_moodle_database extends moodle_database {
+    use moodle_read_slave_trait;
+
+    /** @var array $dbhcursor keep track of open cursors */
+    private $dbhcursor = [];
 
     /** @var resource $pgsql database resource */
     protected $pgsql     = null;
@@ -110,7 +115,6 @@ class pgsql_native_moodle_database extends moodle_database {
 
     /**
      * Connect to db
-     * Must be called before other methods.
      * @param string $dbhost The database host.
      * @param string $dbuser The database username.
      * @param string $dbpass The database username's password.
@@ -120,7 +124,7 @@ class pgsql_native_moodle_database extends moodle_database {
      * @return bool true
      * @throws dml_connection_exception if error
      */
-    public function connect($dbhost, $dbuser, $dbpass, $dbname, $prefix, array $dboptions=null) {
+    public function _connect($dbhost, $dbuser, $dbpass, $dbname, $prefix, array $dboptions=null) {
         if ($prefix == '' and !$this->external) {
             //Enforce prefixes for everybody but mysql
             throw new dml_exception('prefixcannotbeempty', $this->get_dbfamily());
@@ -158,6 +162,10 @@ class pgsql_native_moodle_database extends moodle_database {
                 $port = "port ='".$this->dboptions['dbport']."'";
             }
             $connection = "host='$this->dbhost' $port user='$this->dbuser' password='$pass' dbname='$this->dbname'";
+        }
+
+        if (!empty($this->dboptions['connecttimeout'])) {
+            $connection .= " connect_timeout=".$this->dboptions['connecttimeout'];
         }
 
         if (empty($this->dboptions['dbhandlesoptions'])) {
@@ -234,6 +242,23 @@ class pgsql_native_moodle_database extends moodle_database {
 
 
     /**
+     * Gets db handle currently used with queries
+     * @return resource
+     */
+    protected function db_handle() {
+        return $this->pgsql;
+    }
+
+    /**
+     * Sets db handle to be used with subsequent queries
+     * @param resource $dbh
+     * @return void
+     */
+    protected function set_db_handle($dbh) {
+        $this->pgsql = $dbh;
+    }
+
+    /**
      * Called before each db query.
      * @param string $sql
      * @param array array of parameters
@@ -245,6 +270,28 @@ class pgsql_native_moodle_database extends moodle_database {
         parent::query_start($sql, $params, $type, $extrainfo);
         // pgsql driver tents to send debug to output, we do not need that ;-)
         $this->last_error_reporting = error_reporting(0);
+
+        // ... pg_*lock queries always go to master.
+        if (preg_match('/\bpg_\w*lock/', $sql)) {
+            $this->set_dbhwrite();
+            return;
+        }
+
+        // ... a nuisance - temptables use this
+        if (preg_match('/\bpg_constraint/', $sql) && $this->temptables->get_temptables()) {
+            $this->set_dbhwrite();
+            return;
+        }
+
+        $this->select_db_handle($type, $sql);
+        if (preg_match('/^DECLARE (crs\w*) NO SCROLL CURSOR/', $sql, $match)) {
+            $cursor = $match[1];
+            $this->dbhcursor[$cursor] = $this->pgsql;
+        }
+        if (preg_match('/^(?:FETCH \d+ FROM|CLOSE) (crs\w*)\b/', $sql, $match)) {
+            $cursor = $match[1];
+            $this->pgsql = $this->dbhcursor[$cursor];
+        }
     }
 
     /**
@@ -752,8 +799,6 @@ class pgsql_native_moodle_database extends moodle_database {
 
         list($sql, $params, $type) = $this->fix_sql_params($sql, $params);
 
-        $this->query_start($sql, $params, SQL_QUERY_SELECT);
-
         // For any query that doesn't explicitly specify a limit, we must use cursors to stop it
         // loading the entire thing (unless the config setting is turned off).
         $usecursors = !$limitnum && ($this->get_fetch_buffer_size() > 0);
@@ -766,11 +811,13 @@ class pgsql_native_moodle_database extends moodle_database {
 
             // Do the query to a cursor.
             $sql = 'DECLARE ' . $cursorname . ' NO SCROLL CURSOR WITH HOLD FOR ' . $sql;
-            $result = pg_query_params($this->pgsql, $sql, $params);
         } else {
-            $result = pg_query_params($this->pgsql, $sql, $params);
             $cursorname = '';
         }
+
+        $this->query_start($sql, $params, SQL_QUERY_SELECT);
+
+        $result = pg_query_params($this->pgsql, $sql, $params);
 
         $this->query_end($result);
         if ($usecursors) {

--- a/lib/dml/tests/dml_pgsql_read_slave_test.php
+++ b/lib/dml/tests/dml_pgsql_read_slave_test.php
@@ -1,0 +1,183 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * DML read/read-write database handle use tests
+ *
+ * @package    core
+ * @category   dml
+ * @copyright  2018 Srdjan Janković, Catalyst IT
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+require_once(__DIR__.'/../pgsql_native_moodle_database.php');
+require_once(__DIR__.'/../moodle_temptables.php');
+
+/**
+ * Database driver mock test class that exposes some methods
+ *
+ * @package    core
+ * @category   dml
+ * @copyright  2018 Catalyst IT
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class read_slave_moodle_database_mock extends pgsql_native_moodle_database {
+    /**
+     * @var string
+     */
+    protected $prefix = 't_';
+
+    /**
+     * Constructs a mock db driver
+     *
+     * @param bool $external
+     */
+    public function __construct($external=false) {
+        parent::__construct($external);
+
+        $this->dbhwrite = 'test_rw';
+        $this->dbhreadonly = 'test_ro';
+        $this->set_db_handle($this->dbhwrite);
+
+        $this->temptables = new moodle_temptables($this);
+    }
+
+    // @codingStandardsIgnoreStart
+    /**
+     * Upgrade to public
+     * @return resource
+     */
+    public function db_handle() {
+        return parent::db_handle();
+    }
+
+    /**
+     * Upgrade to public
+     * @param string $sql
+     * @param array $params
+     * @param int $type
+     * @param array $extrainfo
+     */
+    public function query_start($sql, array $params=null, $type, $extrainfo=null) {
+        return parent::query_start($sql, $params, $type);
+    }
+
+    /**
+     * Upgrade to public
+     * @param mixed $result
+     */
+    public function query_end($result) {
+        $this->set_db_handle($this->dbhwrite);
+    }
+
+    /**
+     * Upgrade to public
+     */
+    public function dispose() {
+    }
+    // @codingStandardsIgnoreEnd
+}
+
+/**
+ * DML pgsql_native_moodle_database read slave specific tests
+ *
+ * @package    core
+ * @category   dml
+ * @copyright  2018 Catalyst IT
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class core_dml_pgsql_read_slave_testcase extends base_testcase {
+    /**
+     * Constructs a test case with the given name.
+     *
+     * @param string $name
+     * @param array  $data
+     * @param string $dataname
+     */
+    final public function __construct($name = null, array $data = array(), $dataname = '') {
+        parent::__construct($name, $data, $dataname);
+
+        $this->setBackupGlobals(false);
+        $this->setBackupStaticAttributes(false);
+        $this->setRunTestInSeparateProcess(false);
+    }
+
+    public function test_cursors() {
+        $DB = new read_slave_moodle_database_mock();
+
+        $sql = 'DECLARE crs1 NO SCROLL CURSOR WITH HOLD FOR SELECT * FROM t_table';
+        $DB->query_start($sql, null, SQL_QUERY_SELECT);
+        $DB->query_end(null);
+
+        $DB->query_start("INSERT INTO t_table2 (name) VALUES ('blah')", null, SQL_QUERY_INSERT);
+        $sql = 'DECLARE crs2 NO SCROLL CURSOR WITH HOLD FOR SELECT * FROM t_table2';
+        $DB->query_start($sql, null, SQL_QUERY_SELECT);
+        $DB->query_end(null);
+
+        $sql = 'FETCH 1 FROM crs1';
+        $DB->query_start($sql, null, SQL_QUERY_AUX);
+        $this->assertEquals('test_ro', $DB->db_handle());
+        $DB->query_end(null);
+
+        $sql = 'FETCH 1 FROM crs2';
+        $DB->query_start($sql, null, SQL_QUERY_AUX);
+        $this->assertEquals('test_rw', $DB->db_handle());
+        $DB->query_end(null);
+    }
+
+    public function test_read_pg_table() {
+        $DB = new read_slave_moodle_database_mock();
+
+        $this->assertEquals(0, $DB->perf_get_reads_slave());
+
+        $DB->query_start('SELECT pg_whatever(1)', null, SQL_QUERY_SELECT);
+        $this->assertEquals('test_ro', $DB->db_handle());
+        $DB->query_end(null);
+        $this->assertEquals(1, $DB->perf_get_reads_slave());
+    }
+
+    public function test_read_pg_lock_table() {
+        $DB = new read_slave_moodle_database_mock();
+
+        $this->assertEquals(0, $DB->perf_get_reads_slave());
+
+        foreach (['pg_try_advisory_lock', 'pg_advisory_unlock'] as $fn) {
+            $DB->query_start("SELECT $fn(1)", null, SQL_QUERY_SELECT);
+            $this->assertEquals('test_rw', $DB->db_handle());
+            $DB->query_end(null);
+            $this->assertEquals(0, $DB->perf_get_reads_slave());
+        }
+    }
+
+    public function test_temp_table() {
+        $DB = new read_slave_moodle_database_mock();
+
+        $this->assertEquals(0, $DB->perf_get_reads_slave());
+
+        $dbman = $DB->get_manager();
+        $table = new xmldb_table('silly_test_table');
+        $table->add_field('id', XMLDB_TYPE_INTEGER, 10, null, XMLDB_NOTNULL, XMLDB_SEQUENCE);
+        $table->add_field('msg', XMLDB_TYPE_CHAR, 255);
+        $table->add_key('primary', XMLDB_KEY_PRIMARY, ['id']);
+        $dbman->create_temp_table($table);
+
+        $DB->get_columns('silly_test_table');
+        $DB->get_records('silly_test_table');
+        $this->assertEquals(0, $DB->perf_get_reads_slave());
+    }
+}

--- a/lib/dml/tests/dml_read_slave_test.php
+++ b/lib/dml/tests/dml_read_slave_test.php
@@ -1,0 +1,463 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * DML read/read-write database handle use tests
+ *
+ * @package    core
+ * @category   dml
+ * @copyright  2018 Srdjan Janković, Catalyst IT
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+require_once(__DIR__.'/fixtures/test_moodle_database.php');
+require_once(__DIR__.'/../moodle_read_slave_trait.php');
+
+/**
+ * Database driver test class with moodle_read_slave_trait
+ *
+ * @package    core
+ * @category   dml
+ * @copyright  2018 Catalyst IT
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class read_slave_moodle_database extends test_moodle_database {
+    use moodle_read_slave_trait;
+
+    /** @var string */
+    protected $handle;
+
+    /**
+     * Does not connect to the database. Sets handle property to $dbhost
+     * @param string $dbhost
+     * @param string $dbuser
+     * @param string $dbpass
+     * @param string $dbname
+     * @param mixed $prefix
+     * @param array $dboptions
+     * @return bool true
+     */
+    public function _connect($dbhost, $dbuser, $dbpass, $dbname, $prefix, array $dboptions=null) {
+        $dbport = isset($dboptions['dbport']) ? $dboptions['dbport'] : "";
+        $this->handle = implode(':', [$dbhost, $dbport, $dbuser, $dbpass]);
+        $this->prefix = $prefix;
+
+        if ($dbhost == 'test_ro_fail') {
+            throw new dml_connection_exception($dbhost);
+        }
+
+        return true;
+    }
+
+    /**
+     * Begin database transaction
+     * @return void
+     */
+    protected function begin_transaction() {
+    }
+
+    /**
+     * Commit database transaction
+     * @return void
+     */
+    protected function commit_transaction() {
+    }
+
+    /**
+     * Abort database transaction
+     * @return void
+     */
+    protected function rollback_transaction() {
+        $this->txnhandle = $this->handle;
+    }
+
+    /**
+     * Query wrapper that calls query_start() and query_end()
+     * @param string $sql
+     * @param array $params
+     * @param int $querytype
+     * @return string $handle handle property
+     */
+    private function with_query_start_end($sql, array $params=null, $querytype) {
+        $this->query_start($sql, $params, $querytype);
+        $ret = $this->handle;
+        $this->query_end(null);
+        return $ret;
+    }
+
+    /**
+     * get_dbhwrite()
+     * @return string $dbhwrite handle property
+     */
+    public function get_dbhwrite() {
+        return $this->dbhwrite;
+    }
+
+    /**
+     * get_records_sql() override, calls with_query_start_end()
+     * @param string $sql the SQL select query to execute.
+     * @param array $params array of sql parameters
+     * @param int $limitfrom return a subset of records, starting at this point (optional).
+     * @param int $limitnum return a subset comprising this many records (optional, required if $limitfrom is set).
+     * @return string $handle handle property
+     */
+    public function get_records_sql($sql, array $params=null, $limitfrom=0, $limitnum=0) {
+        list($sql, $params, $type) = $this->fix_sql_params($sql, $params);
+        return $this->with_query_start_end($sql, $params, SQL_QUERY_SELECT);
+    }
+
+    /**
+     * Calls with_query_start_end()
+     * Default implementation, throws Exception
+     * @param string $table
+     * @param array $params
+     * @param bool $returnid
+     * @param bool $bulk
+     * @param bool $customsequence
+     * @return string $handle handle property
+     */
+    public function insert_record_raw($table, $params, $returnid=true, $bulk=false, $customsequence=false) {
+        $fields = implode(',', array_keys($params));
+        $i = 1;
+        foreach ($params as $value) {
+            $values[] = "\$".$i++;
+        }
+        $values = implode(',', $values);
+        $sql = "INSERT INTO {$this->prefix}$table ($fields) VALUES($values)";
+        return $this->with_query_start_end($sql, $params, SQL_QUERY_INSERT);
+    }
+
+    /**
+     * Calls with_query_start_end()
+     * Default implementation, throws Exception
+     * @param string $table
+     * @param array $params
+     * @param bool $bulk
+     * @return string $handle handle property
+     */
+    public function update_record_raw($table, $params, $bulk=false) {
+        $id = $params['id'];
+        unset($params['id']);
+        $i = 1;
+        $sets = array();
+        foreach ($params as $field => $value) {
+            $sets[] = "$field = \$".$i++;
+        }
+        $params[] = $id;
+        $sets = implode(',', $sets);
+        $sql = "UPDATE {$this->prefix}$table SET $sets WHERE id=\$".$i;
+        return $this->with_query_start_end($sql, $params, SQL_QUERY_UPDATE);
+    }
+
+    /**
+     * Gets handle property
+     * @return string $handle handle property
+     */
+    protected function db_handle() {
+        return $this->handle;
+    }
+
+    /**
+     * Sets handle property
+     * @param string $dbh
+     * @return void
+     */
+    protected function set_db_handle($dbh) {
+        $this->handle = $dbh;
+    }
+
+    /**
+     * Add temptable
+     * @param string $temptable
+     * @return void
+     */
+    public function add_temptable($temptable) {
+        $this->temptables->add_temptable($temptable);
+    }
+
+    /**
+     * Remove temptable
+     * @param string $temptable
+     * @return void
+     */
+    public function delete_temptable($temptable) {
+        $this->temptables->delete_temptable($temptable);
+    }
+}
+
+/**
+ * Database driver test class that exposes table_names()
+ *
+ * @package    core
+ * @category   dml
+ * @copyright  2018 Catalyst IT
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class read_slave_moodle_database_table_names extends read_slave_moodle_database {
+    /**
+     * @var string
+     */
+    protected $prefix = 't_';
+
+    // @codingStandardsIgnoreStart
+    /**
+     * Upgrade to public
+     * @param string $sql
+     * @return array
+     */
+    public function table_names($sql) {
+        return parent::table_names($sql);
+    }
+    // @codingStandardsIgnoreEnd
+}
+
+/**
+ * DML read/read-write database handle use tests
+ *
+ * @package    core
+ * @category   dml
+ * @copyright  2018 Catalyst IT
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class core_dml_read_slave_testcase extends base_testcase {
+
+    /** @var float */
+    static private $dbreadonlylatency = 0.8;
+
+    /**
+     * Constructs a test case with the given name.
+     *
+     * @param string $name
+     * @param array  $data
+     * @param string $dataname
+     */
+    final public function __construct($name = null, array $data = array(), $dataname = '') {
+        parent::__construct($name, $data, $dataname);
+
+        $this->setBackupGlobals(false);
+        $this->setBackupStaticAttributes(false);
+        $this->setRunTestInSeparateProcess(false);
+    }
+
+    /**
+     * Instantiates a test database interface object
+     *
+     * @param bool $wantlatency
+     * @param mixed $readonly
+     * @return read_slave_moodle_database $db
+     */
+    public function new_db(
+        $wantlatency=false,
+        $readonly=[
+            ['dbhost' => 'test_ro1', 'dbport' => 1, 'dbuser' => 'test1', 'dbpass' => 'test1'],
+            ['dbhost' => 'test_ro2', 'dbport' => 2, 'dbuser' => 'test2', 'dbpass' => 'test2'],
+        ]
+    ) {
+        $dbhost = 'test_rw';
+        $dbname = 'test';
+        $dbuser = 'test';
+        $dbpass = 'test';
+        $prefix = 'test_';
+        $dboptions = ['readonly' => ['instance' => $readonly, 'exclude_tables' => ['exclude']]];
+        if ($wantlatency) {
+            $dboptions['readonly']['latency'] = self::$dbreadonlylatency;
+        }
+
+        $db = new read_slave_moodle_database();
+        $db->connect($dbhost, $dbuser, $dbpass, $dbname, $prefix, $dboptions);
+        return $db;
+    }
+
+    public function test_table_names() {
+        $t = array(
+            "SELECT *
+             FROM {user} u
+             JOIN (
+                 SELECT DISTINCT u.id FROM {user} u
+                 JOIN {user_enrolments} ue1 ON ue1.userid = u.id
+                 JOIN {enrol} e ON e.id = ue1.enrolid
+                 WHERE u.id NOT IN (
+                     SELECT DISTINCT ue.userid FROM {user_enrolments} ue
+                     JOIN {enrol} e ON (e.id = ue.enrolid AND e.courseid = 1)
+                     WHERE ue.status = 'active'
+                       AND e.status = 'enabled'
+                       AND ue.timestart < now()
+                       AND (ue.timeend = 0 OR ue.timeend > now())
+                 )
+             ) je ON je.id = u.id
+             JOIN (
+                 SELECT DISTINCT ra.userid
+                   FROM {role_assignments} ra
+                  WHERE ra.roleid IN (1, 2, 3)
+                    AND ra.contextid = 'ctx'
+              ) rainner ON rainner.userid = u.id
+              WHERE u.deleted = 0" => [
+                'user',
+                'user',
+                'user_enrolments',
+                'enrol',
+                'user_enrolments',
+                'enrol',
+                'role_assignments',
+            ],
+        );
+
+        $db = new read_slave_moodle_database_table_names();
+        foreach ($t as $sql => $tables) {
+            $this->assertEquals($tables, $db->table_names($db->fix_sql_params($sql)[0]));
+        }
+    }
+
+    public function test_read_read_write_read() {
+        $DB = $this->new_db(true);
+
+        $this->assertEquals(0, $DB->perf_get_reads_slave());
+        $this->assertNull($DB->get_dbhwrite());
+
+        $handle = $DB->get_records('table');
+        $this->assertEquals('test_ro1:1:test1:test1', $handle);
+        $readsslave = $DB->perf_get_reads_slave();
+        $this->assertGreaterThan(0, $readsslave);
+        $this->assertNull($DB->get_dbhwrite());
+
+        $handle = $DB->get_records('table2');
+        $this->assertEquals('test_ro1:1:test1:test1', $handle);
+        $readsslave = $DB->perf_get_reads_slave();
+        $this->assertGreaterThan(1, $readsslave);
+        $this->assertNull($DB->get_dbhwrite());
+
+        $now = microtime(true);
+        $handle = $DB->insert_record_raw('table', array('name' => 'blah'));
+        $this->assertEquals('test_rw::test:test', $handle);
+
+        if (microtime(true) - $now < self::$dbreadonlylatency) {
+            $handle = $DB->get_records('table');
+            $this->assertEquals('test_rw::test:test', $handle);
+            $this->assertEquals($readsslave, $DB->perf_get_reads_slave());
+
+            sleep(1);
+        }
+
+        $handle = $DB->get_records('table');
+        $this->assertEquals('test_ro1:1:test1:test1', $handle);
+        $this->assertEquals($readsslave + 1, $DB->perf_get_reads_slave());
+    }
+
+    public function test_read_write_write() {
+        $DB = $this->new_db();
+
+        $this->assertEquals(0, $DB->perf_get_reads_slave());
+        $this->assertNull($DB->get_dbhwrite());
+
+        $handle = $DB->get_records('table');
+        $this->assertEquals('test_ro1:1:test1:test1', $handle);
+        $readsslave = $DB->perf_get_reads_slave();
+        $this->assertGreaterThan(0, $readsslave);
+        $this->assertNull($DB->get_dbhwrite());
+
+        $handle = $DB->insert_record_raw('table', array('name' => 'blah'));
+        $this->assertEquals('test_rw::test:test', $handle);
+
+        $handle = $DB->update_record_raw('table', array('id' => 1, 'name' => 'blah2'));
+        $this->assertEquals('test_rw::test:test', $handle);
+        $this->assertEquals($readsslave, $DB->perf_get_reads_slave());
+    }
+
+    public function test_write_read_read() {
+        $DB = $this->new_db();
+
+        $this->assertEquals(0, $DB->perf_get_reads_slave());
+        $this->assertNull($DB->get_dbhwrite());
+
+        $handle = $DB->insert_record_raw('table', array('name' => 'blah'));
+        $this->assertEquals('test_rw::test:test', $handle);
+        $this->assertEquals(0, $DB->perf_get_reads_slave());
+
+        sleep(1);
+        $handle = $DB->get_records('table');
+        $this->assertEquals('test_rw::test:test', $handle);
+        $this->assertEquals(0, $DB->perf_get_reads_slave());
+
+        $handle = $DB->get_records('table2');
+        $this->assertEquals('test_ro1:1:test1:test1', $handle);
+        $this->assertEquals(1, $DB->perf_get_reads_slave());
+
+        $handle = $DB->get_records_sql("SELECT * FROM {table2} JOIN {table}");
+        $this->assertEquals('test_rw::test:test', $handle);
+        $this->assertEquals(1, $DB->perf_get_reads_slave());
+    }
+
+    public function test_read_temptable() {
+        $DB = $this->new_db();
+        $DB->add_temptable('temptable1');
+
+        $this->assertEquals(0, $DB->perf_get_reads_slave());
+        $this->assertNull($DB->get_dbhwrite());
+
+        $handle = $DB->get_records('temptable1');
+        $this->assertEquals('test_rw::test:test', $handle);
+        $this->assertEquals(0, $DB->perf_get_reads_slave());
+
+        $DB->delete_temptable('temptable1');
+    }
+
+    public function test_read_excluded_tables() {
+        $DB = $this->new_db();
+
+        $this->assertEquals(0, $DB->perf_get_reads_slave());
+        $this->assertNull($DB->get_dbhwrite());
+
+        $handle = $DB->get_records('exclude');
+        $this->assertEquals('test_rw::test:test', $handle);
+        $this->assertEquals(0, $DB->perf_get_reads_slave());
+    }
+
+    public function test_transaction() {
+        $DB = $this->new_db();
+
+        $this->assertNull($DB->get_dbhwrite());
+
+        $transaction = $DB->start_delegated_transaction();
+        $handle = $DB->get_records_sql("SELECT * FROM {table}");
+        $this->assertEquals('test_rw::test:test', $handle);
+    }
+
+    public function test_read_only_conn_fail() {
+        $DB = $this->new_db(false, 'test_ro_fail');
+
+        $this->assertEquals(0, $DB->perf_get_reads_slave());
+        $this->assertNotNull($DB->get_dbhwrite());
+
+        $handle = $DB->get_records('table');
+        $this->assertEquals('test_rw::test:test', $handle);
+        $readsslave = $DB->perf_get_reads_slave();
+        $this->assertEquals(0, $readsslave);
+    }
+
+    public function test_read_only_conn_first_fail() {
+        $DB = $this->new_db(false, ['test_ro_fail', 'test_ro_ok']);
+
+        $this->assertEquals(0, $DB->perf_get_reads_slave());
+        $this->assertNull($DB->get_dbhwrite());
+
+        $handle = $DB->get_records('table');
+        $this->assertEquals('test_ro_ok::test:test', $handle);
+        $readsslave = $DB->perf_get_reads_slave();
+        $this->assertEquals(1, $readsslave);
+    }
+}

--- a/lib/dml/tests/fixtures/test_moodle_database.php
+++ b/lib/dml/tests/fixtures/test_moodle_database.php
@@ -1,0 +1,485 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Abstract database driver test class providing some moodle database interface
+ *
+ * @package    core
+ * @category   dml
+ * @copyright  2018 Srdjan Janković, Catalyst IT
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+require_once(__DIR__.'/../../moodle_database.php');
+require_once(__DIR__.'/../../moodle_temptables.php');
+require_once(__DIR__.'/../../../ddl/database_manager.php');
+require_once(__DIR__.'/../../../ddl/sql_generator.php');
+
+/**
+ * Test sql generator class
+ *
+ * @package    core
+ * @category   ddl
+ * @copyright  2018 Catalyst IT
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class test_sql_generator extends sql_generator {
+    // @codingStandardsIgnoreStart
+    /**
+     * Reset a sequence to the id field of a table.
+     *
+     * @param xmldb_table|string $table name of table or the table object.
+     * @return array of sql statements
+     */
+    public function getResetSequenceSQL($table) {
+    // @codingStandardsIgnoreEnd
+        return [];
+    }
+
+    // @codingStandardsIgnoreStart
+    /**
+     * Given one correct xmldb_table, returns the SQL statements
+     * to create temporary table (inside one array).
+     *
+     * @param xmldb_table $xmldbtable The xmldb_table object instance.
+     * @return array of sql statements
+     */
+    public function getCreateTempTableSQL($xmldbtable) {
+    // @codingStandardsIgnoreEnd
+        return [];
+    }
+
+    // @codingStandardsIgnoreStart
+    /**
+     * Given one XMLDB Type, length and decimals, returns the DB proper SQL type.
+     *
+     * @param int $xmldbtype The xmldb_type defined constant. XMLDB_TYPE_INTEGER and other XMLDB_TYPE_* constants.
+     * @param int $xmldblength The length of that data type.
+     * @param int $xmldbdecimals The decimal places of precision of the data type.
+     * @return string The DB defined data type.
+     */
+    public function getTypeSQL($xmldbtype, $xmldblength=null, $xmldbdecimals=null) {
+    // @codingStandardsIgnoreEnd
+        return '';
+    }
+
+    // @codingStandardsIgnoreStart
+    /**
+     * Returns the code (array of statements) needed to add one comment to the table.
+     *
+     * @param xmldb_table $xmldbtable The xmldb_table object instance.
+     * @return array Array of SQL statements to add one comment to the table.
+     */
+    function getCommentSQL ($xmldbtable) {
+    // @codingStandardsIgnoreEnd
+        return [];
+    }
+
+    // @codingStandardsIgnoreStart
+    /**
+     * Given one xmldb_table and one xmldb_field, return the SQL statements needed to add its default
+     * (usually invoked from getModifyDefaultSQL()
+     *
+     * @param xmldb_table $xmldbtable The xmldb_table object instance.
+     * @param xmldb_field $xmldbfield The xmldb_field object instance.
+     * @return array Array of SQL statements to create a field's default.
+     */
+    public function getCreateDefaultSQL($xmldbtable, $xmldbfield) {
+    // @codingStandardsIgnoreEnd
+        return [];
+    }
+
+    // @codingStandardsIgnoreStart
+    /**
+     * Given one xmldb_table and one xmldb_field, return the SQL statements needed to drop its default
+     * (usually invoked from getModifyDefaultSQL()
+     *
+     * @param xmldb_table $xmldbtable The xmldb_table object instance.
+     * @param xmldb_field $xmldbfield The xmldb_field object instance.
+     * @return array Array of SQL statements to create a field's default.
+     */
+    public function getDropDefaultSQL($xmldbtable, $xmldbfield) {
+    // @codingStandardsIgnoreEnd
+        return [];
+    }
+
+    // @codingStandardsIgnoreStart
+    /**
+     * Returns an array of reserved words (lowercase) for this DB
+     * @return array An array of database specific reserved words
+     */
+    public static function getReservedWords() {
+    // @codingStandardsIgnoreEnd
+        return [];
+    }
+
+}
+
+/**
+ * Abstract database driver test class
+ *
+ * @package    core
+ * @category   dml
+ * @copyright  2018 Catalyst IT
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+abstract class test_moodle_database extends moodle_database {
+
+    /** @var string */
+    private $error;
+
+    /** @var array */
+    private $_tables = [];
+
+    /**
+     * Constructor - Instantiates the database
+     * @param bool $external True means that an external database is used.
+     */
+    public function __construct($external=false) {
+        parent::__construct($external);
+
+        $this->temptables = new moodle_temptables($this);
+    }
+
+    /**
+     * Default implementation
+     * @return boolean true
+     */
+    public function driver_installed() {
+        return true;
+    }
+
+    /**
+     * Default implementation
+     * @return string 'test'
+     */
+    public function get_dbfamily() {
+        return 'test';
+    }
+
+    /**
+     * Default implementation
+     * @return string 'test'
+     */
+    protected function get_dbtype() {
+        return 'test';
+    }
+
+    /**
+     * Default implementation
+     * @return string 'test'
+     */
+    protected function get_dblibrary() {
+        return 'test';
+    }
+
+    /**
+     * Default implementation
+     * @return string 'test'
+     */
+    public function get_name() {
+        return 'test';
+    }
+
+    /**
+     * Default implementation
+     * @return string
+     */
+    public function get_configuration_help() {
+        return 'test database driver';
+    }
+
+    /**
+     * Default implementation
+     * @return array
+     */
+    public function get_server_info() {
+        return ['description' => $this->name(), 'version' => '0'];
+    }
+
+    /**
+     * Default implementation
+     * @return int 0
+     */
+    protected function allowed_param_types() {
+        return 0;
+    }
+
+    /**
+     * Returns error property
+     * @return string $error
+     */
+    public function get_last_error() {
+        return $this->error;
+    }
+
+    /**
+     * Sets tables property
+     * @param array $tables
+     * @return void
+     */
+    public function set_tables($tables) {
+        $this->_tables = $tables;
+    }
+
+    /**
+     * Returns keys of tables property
+     * @param bool $usecache
+     * @return array $tablenames
+     */
+    public function get_tables($usecache=true) {
+        return array_keys($this->_tables);
+    }
+
+    /**
+     * Return table indexes
+     * @param string $table
+     * @return array $indexes
+     */
+    public function get_indexes($table) {
+        return isset($this->_tables[$table]['indexes']) ? $this->_tables[$table]['indexes'] : [];
+    }
+
+    /**
+     * Return table columns
+     * @param string $table
+     * @param bool $usecache
+     * @return array $indexes
+     */
+    public function get_columns($table, $usecache=true) {
+        return $this->_tables[$table]['columns'];
+    }
+
+    /**
+     * Default implementation
+     * @param StdClass $column metadata
+     * @param mixed $value
+     * @return mixed $value
+     */
+    protected function normalise_value($column, $value) {
+        return $value;
+    }
+
+    /**
+     * Default implementation
+     * @param string|array $sql
+     * @param array|null $tablenames
+     * @return bool true
+     */
+    public function change_database_structure($sql, $tablenames = null) {
+        return true;
+    }
+
+    /**
+     * Default implementation, throws Exception
+     * @param string $sql
+     * @param array $params
+     * @return bool true
+     * @throws Exception
+     */
+    public function execute($sql, array $params = null) {
+        throw new Exception("execute() not implemented");
+    }
+
+    /**
+     * Default implementation, throws Exception
+     * @param string $sql
+     * @param array $params
+     * @param int $limitfrom
+     * @param int $limitnum
+     * @return bool true
+     * @throws Exception
+     */
+    public function get_recordset_sql($sql, array $params=null, $limitfrom=0, $limitnum=0) {
+        throw new Exception("get_recordset_sql() not implemented");
+    }
+
+    /**
+     * Default implementation, throws Exception
+     * @param string $sql
+     * @param array $params
+     * @param int $limitfrom
+     * @param int $limitnum
+     * @return bool true
+     * @throws Exception
+     */
+    public function get_records_sql($sql, array $params=null, $limitfrom=0, $limitnum=0) {
+        throw new Exception("get_records_sql() not implemented");
+    }
+
+    /**
+     * Default implementation, throws Exception
+     * @param string $sql
+     * @param array $params
+     * @return bool true
+     * @throws Exception
+     */
+    public function get_fieldset_sql($sql, array $params=null) {
+        throw new Exception("get_fieldset_sql() not implemented");
+    }
+
+    /**
+     * Default implementation, throws Exception
+     * @param string $table
+     * @param array $params
+     * @param bool $returnid
+     * @param bool $bulk
+     * @param bool $customsequence
+     * @return bool|int true or new id
+     * @throws Exception
+     */
+    public function insert_record_raw($table, $params, $returnid=true, $bulk=false, $customsequence=false) {
+        throw new Exception("insert_record_raw() not implemented");
+    }
+
+    /**
+     * Default implementation, throws Exception
+     * @param string $table
+     * @param StdObject $dataobject
+     * @param bool $returnid
+     * @param bool $bulk
+     * @return bool|int true or new id
+     * @throws Exception
+     */
+    public function insert_record($table, $dataobject, $returnid=true, $bulk=false) {
+        throw new Exception("insert_record() not implemented");
+    }
+
+    /**
+     * Default implementation, throws Exception
+     * @param string $table
+     * @param StdObject $dataobject
+     * @return bool true
+     * @throws Exception
+     */
+    public function import_record($table, $dataobject) {
+        throw new Exception("import_record() not implemented");
+    }
+
+    /**
+     * Default implementation, throws Exception
+     * @param string $table
+     * @param array $params
+     * @param bool $bulk
+     * @return bool true
+     * @throws Exception
+     */
+    public function update_record_raw($table, $params, $bulk=false) {
+        throw new Exception("update_record_raw() not implemented");
+    }
+
+    /**
+     * Default implementation, throws Exception
+     * @param string $table
+     * @param StdObject $dataobject
+     * @param bool $bulk
+     * @return bool true
+     * @throws Exception
+     */
+    public function update_record($table, $dataobject, $bulk=false) {
+        throw new Exception("update_record() not implemented");
+    }
+
+    /**
+     * Default implementation, throws Exception
+     * @param string $table
+     * @param string $newfield
+     * @param string $newvalue
+     * @param string $select
+     * @param array $params
+     * @return bool true
+     * @throws Exception
+     */
+    public function set_field_select($table, $newfield, $newvalue, $select, array $params=null) {
+        throw new Exception("set_field_select() not implemented");
+    }
+
+    /**
+     * Default implementation, throws Exception
+     * @param string $table
+     * @param string $select
+     * @param array $params
+     * @return bool true
+     * @throws Exception
+     */
+    public function delete_records_select($table, $select, array $params=null) {
+        throw new Exception("delete_records_select() not implemented");
+    }
+
+    /**
+     * Default implementation, throws Exception
+     * @return string $sql
+     * @throws Exception
+     */
+    public function sql_concat() {
+        throw new Exception("sql_concat() not implemented");
+    }
+
+    /**
+     * Default implementation, throws Exception
+     * @param string $separator
+     * @param array  $elements
+     * @return string $sql
+     * @throws Exception
+     */
+    public function sql_concat_join($separator="' '", $elements=[]) {
+        throw new Exception("sql_concat_join() not implemented");
+    }
+
+    /**
+     * Default implementation, throws Exception
+     * @return void
+     * @throws Exception
+     */
+    protected function begin_transaction() {
+        throw new Exception("begin_transaction() not implemented");
+    }
+
+    /**
+     * Default implementation, throws Exception
+     * @return void
+     * @throws Exception
+     */
+    protected function commit_transaction() {
+        throw new Exception("commit_transaction() not implemented");
+    }
+
+    /**
+     * Default implementation, throws Exception
+     * @return void
+     * @throws Exception
+     */
+    protected function rollback_transaction() {
+        throw new Exception("rollback_transaction() not implemented");
+    }
+
+    /**
+     * Returns the sql generator used for db manipulation.
+     * Used mostly in upgrade.php scripts.
+     * @return database_manager The instance used to perform ddl operations.
+     * @see lib/ddl/database_manager.php
+     */
+    public function get_manager() {
+        if (!$this->database_manager) {
+            $generator = new test_sql_generator($this, $this->temptables);
+
+            $this->database_manager = new database_manager($this, $generator);
+        }
+        return $this->database_manager;
+    }
+}

--- a/lib/moodlelib.php
+++ b/lib/moodlelib.php
@@ -9435,6 +9435,12 @@ function get_performance_info() {
     $info['html'] .= '<li class="dbqueries col-sm-4">DB reads/writes: '.$info['dbqueries'].'</li> ';
     $info['txt'] .= 'db reads/writes: '.$info['dbqueries'].' ';
 
+    if ($DB->want_read_slave()) {
+        $info['dbreads_slave'] = $DB->perf_get_reads_slave();
+        $info['html'] .= '<li class="dbqueries col-sm-4">DB reads from slave: '.$info['dbreads_slave'].'</li> ';
+        $info['txt'] .= 'db reads from slave: '.$info['dbreads_slave'].' ';
+    }
+
     $info['dbtime'] = round($DB->perf_get_queries_time(), 5);
     $info['html'] .= '<li class="dbtime col-sm-4">DB queries time: '.$info['dbtime'].' secs</li> ';
     $info['txt'] .= 'db queries time: ' . $info['dbtime'] . 's ';


### PR DESCRIPTION
Implemented with moodle_read_slave_trait

Functionality is triggered by supplying config dboption['readonly'].
See config-dist.php for more info on supported dboptions.

pgsql and mysqli drivers are using this feature. Also added support for
connection timeout for these two drivers.

*** PLEASE DO NOT OPEN PULL REQUESTS VIA GITHUB ***

The moodle.git repository at Github is just a mirror of the official repository. We do not accept pull requests at Github.

See CONTRIBUTING.txt guidelines for how to contribute patches for Moodle. Thank you.

--
