### PR TITLE
fix: correct redis retry_interval on correct

### DIFF
--- a/lib/classes/session/redis.php
+++ b/lib/classes/session/redis.php
@@ -165,10 +165,8 @@ class redis extends handler {
 
             try {
 
-                $delay = rand(100000, 500000);
-
                 // One second timeout was chosen as it is long for connection, but short enough for a user to be patient.
-                if (!$this->connection->connect($this->host, $this->port, 1, null, $delay)) {
+                if (!$this->connection->connect($this->host, $this->port, 1, null, 1000)) {
                     throw new RedisException('Unable to connect to host.');
                 }
 


### PR DESCRIPTION
The redis session was using a delay value designed for
microseconds as the value to retry_interval (which is ms).

Remove the use of the random delay (this is used for reconnect
in the outer loop) and set to 1000 (e.g. 1s).

*** PLEASE DO NOT OPEN PULL REQUESTS VIA GITHUB ***

The moodle.git repository at Github is just a mirror of the official repository. We do not accept pull requests at Github.

See CONTRIBUTING.txt guidelines for how to contribute patches for Moodle. Thank you.

--
