### PR TITLE
Conflicting behavior

### DIFF
--- a/repository/nextcloud/lib.php
+++ b/repository/nextcloud/lib.php
@@ -650,11 +650,13 @@ class repository_nextcloud extends repository {
      * @throws dml_exception
      */
     public static function instance_config_form($mform) {
+        /*
         if (!has_capability('moodle/site:config', context_system::instance())) {
             $mform->addElement('static', null, '',  get_string('nopermissions', 'error', get_string('configplugin',
                 'repository_nextcloud')));
             return false;
         }
+        */
 
         // Load configured issuers.
         $issuers = core\oauth2\api::get_all_issuers();


### PR DESCRIPTION
The lines, that I commented out, prevent this plugin from working as expected.

The problem is as follows:

(1) As a site-admin I have to create every nextCloud-Instance as an oAuth-Service.
(2) I have to configure the nextCloud-Repository.
(3) I can choose, if I  create those nextCloud-Instances as site-wide nextCloud-Repositories, or
(4) allow users optionally to select on their own nextCloud in the personal settings area. 

This step (4) requires users to edit the nextcloud instances in their personal settings area. The lines, that I commented out, require site administration capabilties. Therefore they prevent users from configuring the instances, although they see the link "add nextcloud repository".

Consequently in my opinion, these lines have to be removed.

*** PLEASE DO NOT OPEN PULL REQUESTS VIA GITHUB ***

The moodle.git repository at Github is just a mirror of the official repository. We do not accept pull requests at Github.

See CONTRIBUTING.txt guidelines for how to contribute patches for Moodle. Thank you.

--
