### PR TITLE
MDL-69181 code area: Enabling profile params in LTI custom params

### DIFF
--- a/mod/lti/locallib.php
+++ b/mod/lti/locallib.php
@@ -2043,13 +2043,18 @@ function lti_parse_custom_parameter($toolproxy, $tool, $params, $value, $islti2)
                     }
                 } else {
                     $val = $value;
-                    $services = lti_get_services();
-                    foreach ($services as $service) {
-                        $service->set_tool_proxy($toolproxy);
-                        $service->set_type($tool);
-                        $value = $service->parse_value($val);
-                        if ($val != $value) {
-                            break;
+                    // MDL-69181 trying to calculate the custom params
+                    // If not exist the function return null and to continue with the normal flow.
+                    $value = lti_calculate_custom_parameter($value1);
+                    if ($value == null) {
+                        $services = lti_get_services();
+                        foreach ($services as $service) {
+                            $service->set_tool_proxy($toolproxy);
+                            $service->set_type($tool);
+                            $value = $service->parse_value($val);
+                            if ($val != $value) {
+                                break;
+                            }
                         }
                     }
                 }
@@ -2074,6 +2079,20 @@ function lti_calculate_custom_parameter($value) {
             return implode(",", groups_get_user_groups($COURSE->id, $USER->id)[0]);
         case 'Context.id.history':
             return implode(",", get_course_history($COURSE));
+    }
+
+    $valueinfo = explode('.', $value);
+    // If the value contain User, we try to find the property in the User fields or Profile fields.
+    if ($valueinfo[0] === 'User') {
+        $property = $valueinfo[1];
+        if (property_exists($USER, $property)) {
+            return $USER->{$property} == "" ? null : $USER->{$property};
+        }
+        // If the property doesn't exist in the User object, we try on to find it in the profile fields.
+        $profile = (object)profile_user_record($USER->id);
+        if (property_exists($profile, $property)) {
+            return $profile->{$property} == "" ? null : $profile->{$property};
+        }
     }
     return null;
 }

--- a/mod/lti/tests/locallib_test.php
+++ b/mod/lti/tests/locallib_test.php
@@ -1740,6 +1740,29 @@ MwIDAQAB
         $this->assertEquals(get_course_history($course), [38903]);
     }
 
+    public function test_user_dynamic_custom_parameters() {
+        $this->resetAfterTest();
+
+        $tool = new stdClass();
+        $tool->enabledcapability = '';
+        $tool->parameter = '';
+        $tool->ltiversion = 'LTI-1p0';
+        // Test custom parameter that returns $USER property.
+        $user = $this->getDataGenerator()->create_user(array('middlename' => 'SOMETHING',
+            'skype' => 'test@hotmail.com',
+            'icq' => '11223344',
+            'country' => 'MX',
+            'msn' => 'test@hotmail.com'));
+        $this->setUser($user);
+        $this->assertEquals(array('custom_x' => '1',
+            'custom_y' => 'test@hotmail.com',
+            'custom_z' => '11223344', 'custom_aa' => 'MX',
+            'custom_ab' => 'test@hotmail.com'),
+            lti_split_custom_parameters(null, $tool,
+                array(), "x=1\ny=\$User.skype\nz=\$User.icq\naa=\$User.country\nab=\$User.msn",
+                false));
+    }
+
     /**
      * Create an LTI Tool.
      *


### PR DESCRIPTION
Enabling the ability of the External Tool capability to pull custom parameters from the scope of "User".

In some LTI services it is required to send information that currently cannot be sent dynamically as a custom parameter, this change is to solve this problem.

Currently, you have access to all the user information found in the mdl_user table, but with this modification you can access the user's profile fields.

If you add a new profile field, you can't use inside the External Tools (LTI)  as a parameter of the custom parameters.
