### PR TITLE
MDL-69451 dml: use same temptables for both rw and ro database handle

### DIFF
--- a/lib/dml/moodle_read_slave_trait.php
+++ b/lib/dml/moodle_read_slave_trait.php
@@ -226,9 +226,13 @@ trait moodle_read_slave_trait {
      * @return void
      */
     private function set_dbhwrite(): void {
-        // Late connect to read/write master if needed.
+        // Lazy connect to read/write master.
         if (!$this->dbhwrite) {
+            $temptables = $this->temptables;
             $this->raw_connect($this->pdbhost, $this->pdbuser, $this->pdbpass, $this->pdbname, $this->pprefix, $this->pdboptions);
+            if ($temptables) {
+                $this->temptables = $temptables; // Restore temptables, so we don't get separate sets for rw and ro.
+            }
             $this->dbhwrite = $this->get_db_handle();
         }
         $this->set_db_handle($this->dbhwrite);

--- a/lib/dml/pgsql_native_moodle_database.php
+++ b/lib/dml/pgsql_native_moodle_database.php
@@ -295,7 +295,7 @@ class pgsql_native_moodle_database extends moodle_database {
         }
 
         // ... a nuisance - temptables use this.
-        if (preg_match('/\bpg_constraint/', $sql) && $this->temptables->get_temptables()) {
+        if (preg_match('/\bpg_catalog/', $sql) && $this->temptables->get_temptables()) {
             return false;
         }
 


### PR DESCRIPTION
moodle_read_slave_trait: when creating another handle, restore temptables
property that is clobbered by raw_connect().

Also a better condition for temptable related queries detection in
pgsql_native_moodle_database.

dml_pgsql_read_slave_test::test_temp_table(): use real db connection
if possible, otherwise skip the test.

*** PLEASE DO NOT OPEN PULL REQUESTS VIA GITHUB ***

The moodle.git repository at Github is just a mirror of the official repository. We do not accept pull requests at Github.

See CONTRIBUTING.txt guidelines for how to contribute patches for Moodle. Thank you.

--
