### PR TITLE
course externallib.php | Call to undefined function bug fix

### DIFF
--- a/course/externallib.php
+++ b/course/externallib.php
@@ -29,7 +29,7 @@ defined('MOODLE_INTERNAL') || die;
 use core_course\external\course_summary_exporter;
 
 require_once("$CFG->libdir/externallib.php");
-require_once("lib.php");
+require_once(__DIR__."/lib.php");
 
 /**
  * Course external functions


### PR DESCRIPTION
Following error throw during `core_course_get_recent_courses` API call in rest (php version PHP 7.4.11)
`Call to undefined function course_get_recent_courses()`