### PR TITLE
Check the port and path into reverseproxy checking

### DIFF
--- a/lib/setuplib.php
+++ b/lib/setuplib.php
@@ -900,7 +900,11 @@ function initialise_fullme() {
 
     // hopefully this will stop all those "clever" admins trying to set up moodle
     // with two different addresses in intranet and Internet
-    if (!empty($CFG->reverseproxy) && $rurl['host'] === $wwwroot['host']) {
+    if (!empty($CFG->reverseproxy) && 
+        $rurl['host'] === $wwwroot['host'] && 
+        (!empty($wwwroot['port']) and $rurl['port'] == $wwwroot['port']) &&
+        !(strpos($rurl['path'], $wwwroot['path']) !== 0)
+    ) {
         print_error('reverseproxyabused', 'error');
     }
 


### PR DESCRIPTION
When I'm trying to deploy a moodle instance into a docker container and I map a different port into the docker container than the http server is running into the container I got 2 different unexpecting scenarios:

- With $CFG->reverseproxy set to false or unset: continuously redirected (303) to the namespace and port that I'm requesting.
- With $CFG->reverseproxy set to true: get the reverseproxyabused error.

That happens because the condition to the first time that is checking the URL requested and the time that is checking the abuse of a reverse proxy are different.

*** PLEASE DO NOT OPEN PULL REQUESTS VIA GITHUB ***

The moodle.git repository at Github is just a mirror of the official repository. We do not accept pull requests at Github.

See CONTRIBUTING.txt guidelines for how to contribute patches for Moodle. Thank you.

--
