### PR TITLE
Avoid PHP NOTICE message undefined variable: overall in badges/criteria/award_criteria_courseset.php

### DIFF
--- a/badges/criteria/award_criteria_courseset.php
+++ b/badges/criteria/award_criteria_courseset.php
@@ -238,7 +238,7 @@ class award_criteria_courseset extends award_criteria {
             }
         }
 
-        return $overall;
+        return isset($overall) ? $overall: false;
     }
 
     /**


### PR DESCRIPTION
    Undefined variable: overall in
    /www/badges/criteria/award_criteria_courseset.php on line 241

This happens if the foreach loop [line 200] is not executed once.

Issue: MDL-73091

*** PLEASE DO NOT OPEN PULL REQUESTS VIA GITHUB ***

The moodle.git repository at Github is just a mirror of the official repository. We do not accept pull requests at Github.

See CONTRIBUTING.txt guidelines for how to contribute patches for Moodle. Thank you.

--
