### PR TITLE
Don't override LTI tool icon colors.

### DIFF
--- a/theme/boost/scss/moodle/icons.scss
+++ b/theme/boost/scss/moodle/icons.scss
@@ -147,7 +147,7 @@ $iconsizes: map-merge((
 }
 
 @each $type, $value in $activity-icon-colors {
-    .activityiconcontainer.#{$type} {
+    .activityiconcontainer.#{$type}:not(.modicon_lti) {
         background-color: $value;
         .activityicon,
         .icon {


### PR DESCRIPTION
This class is adding a brightness of 0 and then inverting it, essentially making all images a white outline or png. While this was presumably done for standard icons where the icons are known to work, the icons can also be LTI tool icons that are added dynamically via external tools.  When you do that, it makes the icons completely white, unlike the icon that shows up in the LTI administrative view.

One could argue that providers of LTI should offer up a transparent PNG, but LTI tool endpoints are almost always static for any LMS. So that would mean a white/blank image in other LMS's that aren't Moodle.  Moodle should respect the logo as designated by LTI.

Happy to paste examples if allowed to update w/ images.

*** PLEASE DO NOT OPEN PULL REQUESTS VIA GITHUB ***

The moodle.git repository at Github is just a mirror of the official repository. We do not accept pull requests at Github.

See CONTRIBUTING.txt guidelines for how to contribute patches for Moodle. Thank you.

--
