### PR TITLE
MDL-77832

### DIFF
--- a/mod/assign/feedback/editpdf/classes/combined_document.php
+++ b/mod/assign/feedback/editpdf/classes/combined_document.php
@@ -304,6 +304,11 @@ class combined_document {
         // Store the newly created file as a stored_file.
         $this->store_combined_file($tmpfile, $contextid, $itemid, ($currentstatus == self::STATUS_READY_PARTIAL));
 
+	unlink($tmpfile);
+        foreach ($compatiblepdfs as $compatiblepdf) {
+            unlink($compatiblepdf);
+        }
+
         // Note the verified page count.
         $this->pagecount = $verifypagecount;
 
@@ -407,7 +412,7 @@ class combined_document {
             // Something went wrong. Return an empty page count again.
             return 0;
         }
-
+        unlink($tempsrc);
         $this->pagecount = $pagecount;
         return $this->pagecount;
     }


### PR DESCRIPTION
The job \mod_assign\task\cron_task ultimatily calls to [this line](https://github.com/moodle/moodle/blob/MOODLE_311_STABLE/mod/assign/feedback/editpdf/classes/combined_document.php#L305)

During this job, the platform will for each student assignment submission compile each file submitted

For treatment purposes the same file will be duplicated and compiled 3 times

None of theses files are deleted until the process is all done.

On large platform with large submission numbers and large files this will generate a storage issue.

This patch makes sure that unused file are getting rid of during the job, allowing a better disk space management.