### PR TITLE
MDL-73626 mod_assign: release individual grades when assignment is an…

### DIFF
--- a/mod/assign/backup/moodle2/backup_assign_stepslib.php
+++ b/mod/assign/backup/moodle2/backup_assign_stepslib.php
@@ -91,6 +91,7 @@ class backup_assign_activity_structure_step extends backup_activity_structure_st
                                                   'maxattempts',
                                                   'markingworkflow',
                                                   'markingallocation',
+                                                  'markinganonymous',
                                                   'preventsubmissionnotingroup',
                                                   'activity',
                                                   'activityformat',

--- a/mod/assign/backup/moodle2/restore_assign_stepslib.php
+++ b/mod/assign/backup/moodle2/restore_assign_stepslib.php
@@ -125,6 +125,9 @@ class restore_assign_activity_structure_step extends restore_activity_structure_
         if (!isset($data->markingallocation)) {
             $data->markingallocation = 0;
         }
+        if (!isset($data->markinganonymous)) {
+            $data->markinganonymous = 0;
+        }
         if (!isset($data->preventsubmissionnotingroup)) {
             $data->preventsubmissionnotingroup = 0;
         }

--- a/mod/assign/db/install.xml
+++ b/mod/assign/db/install.xml
@@ -34,6 +34,7 @@
         <FIELD NAME="maxattempts" TYPE="int" LENGTH="6" NOTNULL="true" DEFAULT="-1" SEQUENCE="false" COMMENT="What is the maximum number of student attempts allowed for this assignment? -1 means unlimited."/>
         <FIELD NAME="markingworkflow" TYPE="int" LENGTH="2" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="If enabled, marking workflow features will be used in this assignment."/>
         <FIELD NAME="markingallocation" TYPE="int" LENGTH="2" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="If enabled, marking allocation features will be used in this assignment"/>
+        <FIELD NAME="markinganonymous" TYPE="int" LENGTH="2" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="If enabled, marking anonymous features will be used in this assignment"/>
         <FIELD NAME="sendstudentnotifications" TYPE="int" LENGTH="2" NOTNULL="true" DEFAULT="1" SEQUENCE="false" COMMENT="Default for send student notifications checkbox when grading."/>
         <FIELD NAME="preventsubmissionnotingroup" TYPE="int" LENGTH="2" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="If enabled a user will be unable to make a submission unless they are a member of a group."/>
         <FIELD NAME="activity" TYPE="text" NOTNULL="false" SEQUENCE="false"/>

--- a/mod/assign/db/upgrade.php
+++ b/mod/assign/db/upgrade.php
@@ -130,6 +130,19 @@ function xmldb_assign_upgrade($oldversion) {
         // Assignment savepoint reached.
         upgrade_mod_savepoint(true, 2022071300, 'assign');
     }
+
+    if ($oldversion < 2023071800) {
+        // Define field activity to be added to assign.
+        $table = new xmldb_table('assign');
+        $field = new xmldb_field('markinganonymous', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0', 'markingallocation');
+        // Conditionally launch add field activity.
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        // Assign savepoint reached.
+        upgrade_mod_savepoint(true, 2023071800, 'assign');
+    }
     // Automatically generated Moodle v4.1.0 release upgrade line.
     // Put any upgrade step following this.
 

--- a/mod/assign/externallib.php
+++ b/mod/assign/externallib.php
@@ -357,6 +357,7 @@ class mod_assign_external extends \mod_assign\external\external_api {
                      'm.maxattempts, ' .
                      'm.markingworkflow, ' .
                      'm.markingallocation, ' .
+                     'm.markinganonymous, ' .
                      'm.requiresubmissionstatement, '.
                      'm.preventsubmissionnotingroup, '.
                      'm.intro, '.
@@ -435,6 +436,7 @@ class mod_assign_external extends \mod_assign\external\external_api {
                         'maxattempts' => $module->maxattempts,
                         'markingworkflow' => $module->markingworkflow,
                         'markingallocation' => $module->markingallocation,
+                        'markinganonymous' => $module->markinganonymous,
                         'requiresubmissionstatement' => $module->requiresubmissionstatement,
                         'preventsubmissionnotingroup' => $module->preventsubmissionnotingroup,
                         'timelimit' => $module->timelimit,
@@ -553,6 +555,7 @@ class mod_assign_external extends \mod_assign\external\external_api {
                 'maxattempts' => new external_value(PARAM_INT, 'maximum number of attempts allowed'),
                 'markingworkflow' => new external_value(PARAM_INT, 'enable marking workflow'),
                 'markingallocation' => new external_value(PARAM_INT, 'enable marking allocation'),
+                'markinganonymous' => new external_value(PARAM_INT, 'enable marking anonymous'),
                 'requiresubmissionstatement' => new external_value(PARAM_INT, 'student must accept submission statement'),
                 'preventsubmissionnotingroup' => new external_value(PARAM_INT, 'Prevent submission not in group', VALUE_OPTIONAL),
                 'submissionstatement' => new external_value(PARAM_RAW, 'Submission statement formatted.', VALUE_OPTIONAL),

--- a/mod/assign/lang/en/assign.php
+++ b/mod/assign/lang/en/assign.php
@@ -344,8 +344,11 @@ $string['markerfilter'] = 'Marker filter';
 $string['markerfilternomarker'] = 'No marker';
 $string['markingallocation'] = 'Use marking allocation';
 $string['markingallocation_help'] = 'If enabled together with marking workflow, markers can be allocated to particular students.';
+$string['markinganonymous'] = 'Use marking anonymous';
+$string['markinganonymous_help'] = 'If enabled together with anonymous submissions and marking workflow, markers can release individual grades.';
 $string['markingworkflow'] = 'Use marking workflow';
 $string['markingworkflow_help'] = 'If enabled, marks will go through a series of workflow stages before being released to students. This allows for multiple rounds of marking and allows marks to be released to all students at the same time.';
+
 $string['markingworkflowstate'] = 'Marking workflow state';
 $string['markingworkflowstate_help'] = 'Possible workflow states may include (depending on your permissions):
 

--- a/mod/assign/locallib.php
+++ b/mod/assign/locallib.php
@@ -766,6 +766,11 @@ class assign {
         if (empty($update->markingworkflow)) { // If marking workflow is disabled, make sure allocation is disabled.
             $update->markingallocation = 0;
         }
+        $update->markinganonymous = $formdata->markinganonymous;
+        // If marking workflow is disabled, or anonymous submissions is disabled then make sure marking anonymous is disabled.
+        if (empty($update->markingworkflow) || empty($update->blindmarking)) {
+            $update->markinganonymous = 0;
+        }
 
         $returnid = $DB->insert_record('assign', $update);
         $this->instance = $DB->get_record('assign', array('id'=>$returnid), '*', MUST_EXIST);
@@ -1533,6 +1538,11 @@ class assign {
         $update->markingallocation = $formdata->markingallocation;
         if (empty($update->markingworkflow)) { // If marking workflow is disabled, make sure allocation is disabled.
             $update->markingallocation = 0;
+        }
+        $update->markinganonymous = $formdata->markinganonymous;
+        // If marking workflow is disabled, or blindmarking is disabled then make sure marking anonymous is disabled.
+        if (empty($update->markingworkflow) || empty($update->blindmarking)) {
+            $update->markinganonymous = 0;
         }
 
         $result = $DB->update_record('assign', $update);
@@ -8452,6 +8462,10 @@ class assign {
                     // Set assign gradebook feedback plugin status.
                     $assign->gradefeedbackenabled = $this->is_gradebook_feedback_enabled();
 
+                    // If markinganonymous is enabled then allow to release grades anonymously.
+                    if (isset($assign->markinganonymous) && $assign->markinganonymous == 1) {
+                        assign_update_grades($assign, $userid);
+                    }
                     $user = $DB->get_record('user', array('id' => $userid), '*', MUST_EXIST);
                     \mod_assign\event\workflow_state_updated::create_from_user($this, $user, $state)->trigger();
                 }

--- a/mod/assign/mod_form.php
+++ b/mod/assign/mod_form.php
@@ -226,6 +226,12 @@ class mod_assign_mod_form extends moodleform_mod {
         $mform->addHelpButton('markingallocation', 'markingallocation', 'assign');
         $mform->hideIf('markingallocation', 'markingworkflow', 'eq', 0);
 
+        $name = get_string('markinganonymous', 'assign');
+        $mform->addElement('selectyesno', 'markinganonymous', $name);
+        $mform->addHelpButton('markinganonymous', 'markinganonymous', 'assign');
+        $mform->hideIf('markinganonymous', 'markingworkflow', 'eq', 0);
+        $mform->hideIf('markinganonymous', 'blindmarking', 'eq', 0);
+
         $this->standard_coursemodule_elements();
         $this->apply_admin_defaults();
 

--- a/mod/assign/settings.php
+++ b/mod/assign/settings.php
@@ -329,6 +329,16 @@ if ($ADMIN->fulltree) {
     $setting->set_advanced_flag_options(admin_setting_flag::ENABLED, false);
     $setting->set_locked_flag_options(admin_setting_flag::ENABLED, false);
     $settings->add($setting);
+
+    $name = new lang_string('markinganonymous', 'mod_assign');
+    $description = new lang_string('markinganonymous_help', 'mod_assign');
+    $setting = new admin_setting_configcheckbox('assign/markinganonymous',
+                                                    $name,
+                                                    $description,
+                                                    0);
+    $setting->set_advanced_flag_options(admin_setting_flag::ENABLED, false);
+    $setting->set_locked_flag_options(admin_setting_flag::ENABLED, false);
+    $settings->add($setting);
 }
 
 $ADMIN->add('modassignfolder', $settings);

--- a/mod/assign/tests/behat/bulk_release_anon_submissions.feature
+++ b/mod/assign/tests/behat/bulk_release_anon_submissions.feature
@@ -28,6 +28,7 @@ Feature: Bulk released grades should not be sent to gradebook while submissions 
       | assignsubmission_onlinetext_enabled | 1                           |
       | assignsubmission_file_enabled       | 0                           |
       | markingworkflow                     | 1                           |
+      | markinganonymous                    | 0                           |
       | blindmarking                        | 1                           |
       | assignfeedback_comments_enabled     | 1                           |
       | assignfeedback_editpdf_enabled      | 1                           |

--- a/mod/assign/tests/generator/lib.php
+++ b/mod/assign/tests/generator/lib.php
@@ -56,6 +56,7 @@ class mod_assign_generator extends testing_module_generator {
             'maxattempts'                       => -1,
             'markingworkflow'                   => 0,
             'markingallocation'                 => 0,
+            'markinganonymous'                  => 0,
             'activityformat'                    => 0,
             'timelimit'                         => 0,
             'submissionattachments'             => 0,

--- a/mod/assign/version.php
+++ b/mod/assign/version.php
@@ -25,5 +25,5 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'mod_assign'; // Full name of the plugin (used for diagnostics).
-$plugin->version  = 2023042400;    // The current module version (Date: YYYYMMDDXX).
+$plugin->version  = 2023071800;    // The current module version (Date: YYYYMMDDXX).
 $plugin->requires = 2023041800;    // Requires this Moodle version.


### PR DESCRIPTION
…onymous

Adds a new setting, markinganonymous, which if enabled together with anonymous submissions and marking workflow, allows markers to release individual grades.

	modified:   mod/assign/backup/moodle2/backup_assign_stepslib.php
	modified:   mod/assign/backup/moodle2/restore_assign_stepslib.php
	modified:   mod/assign/db/install.xml
	modified:   mod/assign/db/upgrade.php
	modified:   mod/assign/externallib.php
	modified:   mod/assign/lang/en/assign.php
	modified:   mod/assign/locallib.php
	modified:   mod/assign/mod_form.php
	modified:   mod/assign/settings.php
	modified:   mod/assign/tests/behat/bulk_release_anon_submissions.feature
	modified:   mod/assign/tests/generator/lib.php
	modified:   mod/assign/version.php

*** PLEASE DO NOT OPEN PULL REQUESTS VIA GITHUB ***

The moodle.git repository at Github is just a mirror of the official repository. We do not accept pull requests at Github.

See CONTRIBUTING.txt guidelines for how to contribute patches for Moodle. Thank you.

--
