### PR TITLE
Update CHUNKED_READ_BLOCK_SIZE to lower amount

### DIFF
--- a/lib/zipstream/src/File.php
+++ b/lib/zipstream/src/File.php
@@ -25,7 +25,7 @@ class File
 
     public const SEND = 2;
 
-    private const CHUNKED_READ_BLOCK_SIZE = 1048576;
+    private const CHUNKED_READ_BLOCK_SIZE = 1024;
 
     /**
      * @var string


### PR DESCRIPTION
Issue when downloading a large file through Moodle from S3 can result in errors such as:

warning [STAT0023_22-23.zip]: 5268 extra bytes at beginning or within zipfile (attempting to process anyway)
file #1: bad zipfile offset (local header sig): 5268

Reducing the CHUNKED_READ_BLOCK_SIZE resolves this issue

*** PLEASE DO NOT OPEN PULL REQUESTS VIA GITHUB ***

The moodle.git repository at Github is just a mirror of the official repository. We do not accept pull requests at Github.

See CONTRIBUTING.txt guidelines for how to contribute patches for Moodle. Thank you.

--
