### PR TITLE
MDL-79342: Remove '.muted' class instances

### DIFF
--- a/admin/tool/componentlibrary/content/bootstrap/components/tooltips.md
+++ b/admin/tool/componentlibrary/content/bootstrap/components/tooltips.md
@@ -46,7 +46,7 @@ $(function () {
 Hover over the links below to see tooltips:
 
 <div class="bd-example tooltip-demo">
-  <p class="muted">Placeholder text to demonstrate some <a href="#" data-toggle="tooltip" title="Default tooltip">inline links</a> with tooltips. This is now just filler, no killer. Content placed here just to mimic the presence of <a href="#" data-toggle="tooltip" title="Another tooltip">real text</a>. And all that just to give you an idea of how tooltips would look when used in real-world situations. So hopefully you've now seen how <a href="#" data-toggle="tooltip" title="Another one here too">these tooltips on links</a> can work in practice, once you use them on <a href="#" data-toggle="tooltip" title="The last tip!">your own</a> site or project.
+  <p class="text-muted">Placeholder text to demonstrate some <a href="#" data-toggle="tooltip" title="Default tooltip">inline links</a> with tooltips. This is now just filler, no killer. Content placed here just to mimic the presence of <a href="#" data-toggle="tooltip" title="Another tooltip">real text</a>. And all that just to give you an idea of how tooltips would look when used in real-world situations. So hopefully you've now seen how <a href="#" data-toggle="tooltip" title="Another one here too">these tooltips on links</a> can work in practice, once you use them on <a href="#" data-toggle="tooltip" title="The last tip!">your own</a> site or project.
   </p>
 </div>
 

--- a/admin/tool/policy/templates/page_managedocs_list.mustache
+++ b/admin/tool/policy/templates/page_managedocs_list.mustache
@@ -106,7 +106,7 @@
                 {{/indented}}
                 <div {{#indented}}style="margin-left: 24px" {{/indented}}>
                     <div>{{{name}}}</div>
-                    <div class="text-muted, muted"><small>{{{typetext}}}, {{{audiencetext}}}, {{{optionaltext}}}</small></div>
+                    <div class="text-muted"><small>{{{typetext}}}, {{{audiencetext}}}, {{{optionaltext}}}</small></div>
                 </div>
             </td>
             <td>
@@ -114,7 +114,7 @@
             </td>
             <td>
                 {{revision}}
-                <div class="text-muted, muted">
+                <div class="text-muted">
                     <small>
                         <time title="{{#str}} lastmodified, core {{/str}}" datetime="{{#userdate}} {{timemodified}}, %Y-%m-%dT%T%z {{/userdate}}">
                             {{#userdate}} {{timemodified}}, {{#str}} strftimedatetime, core_langconfig {{/str}} {{/userdate}}

--- a/blocks/myoverview/templates/view-list.mustache
+++ b/blocks/myoverview/templates/view-list.mustache
@@ -51,7 +51,7 @@
                 </div>
                 <div class="col-md-9 d-flex flex-column">
                     {{#showshortname}}
-                        <div class="text-muted muted d-flex flex-wrap">
+                        <div class="text-muted d-flex flex-wrap">
                             {{#showcoursecategory}}
                                 <div class="pl-1 pr-1">|</div>
                             {{/showcoursecategory}}
@@ -69,7 +69,7 @@
                         {{{fullname}}}
                     </a>
                     {{#showcoursecategory}}
-                        <div class="text-muted muted d-flex flex-wrap">
+                        <div class="text-muted d-flex flex-wrap">
                             <span class="sr-only">
                                 {{#str}}aria:coursecategory, core_course{{/str}}
                             </span>
@@ -84,7 +84,7 @@
                         </div>
                     {{/visible}}
                     {{#hasprogress}}
-                        <div class="text-muted muted d-flex flex-wrap mt-auto">
+                        <div class="text-muted d-flex flex-wrap mt-auto">
                             {{> block_myoverview/progress-bar}}
                         </div>
                     {{/hasprogress}}

--- a/blocks/myoverview/templates/view-summary.mustache
+++ b/blocks/myoverview/templates/view-summary.mustache
@@ -51,7 +51,7 @@
             </div>
             <div class="col-md-9 d-flex flex-column">
                 {{#showshortname}}
-                    <div class="text-muted muted d-flex flex-wrap">
+                    <div class="text-muted d-flex flex-wrap">
                         {{#showcoursecategory}}
                             <div class="pl-1 pr-1">|</div>
                         {{/showcoursecategory}}
@@ -90,7 +90,7 @@
                     {{{summary}}}
                 </div>
                 {{#hasprogress}}
-                    <div class="text-muted muted d-flex flex-wrap mt-auto">
+                    <div class="text-muted d-flex flex-wrap mt-auto">
                         {{> block_myoverview/progress-bar}}
                     </div>
                 {{/hasprogress}}

--- a/blocks/rss_client/templates/item.mustache
+++ b/blocks/rss_client/templates/item.mustache
@@ -52,7 +52,7 @@
 
     {{$content}}
         {{#description}}
-            <div class="date text-muted muted mb-1">
+            <div class="date text-muted mb-1">
                 <small>{{{datepublished}}}</small>
             </div>
             <div class="description">

--- a/course/templates/activityinstance.mustache
+++ b/course/templates/activityinstance.mustache
@@ -57,7 +57,7 @@
             {{/completionstatus.icon}}
         </div>
         <div class="col-sm-11  pl-0">
-            <span class="text-muted muted">{{{completionstatus.string}}}</span>
+            <span class="text-muted">{{{completionstatus.string}}}</span>
         </div>
     </div>
 </div>

--- a/course/templates/coursecard.mustache
+++ b/course/templates/coursecard.mustache
@@ -46,7 +46,7 @@
         <div class="d-flex align-items-start">
             <div class="w-100 text-truncate">
                 {{#showshortname}}
-                    <div class="text-muted muted d-flex mb-1 flex-wrap">
+                    <div class="text-muted d-flex mb-1 flex-wrap">
                         <span class="sr-only">
                             {{#str}}aria:courseshortname, core_course{{/str}}
                         </span>
@@ -62,7 +62,7 @@
                     </span>
                     {{$coursename}}{{/coursename}}
                 </a>
-                <div class="text-muted muted d-flex flex-wrap">
+                <div class="text-muted d-flex flex-wrap">
                     {{$coursecategory}}{{/coursecategory}}
                 </div>
                 {{^visible}}

--- a/course/templates/defaultactivitycompletion.mustache
+++ b/course/templates/defaultactivitycompletion.mustache
@@ -77,7 +77,7 @@
                             {{/completionstatus.icon}}
                         </div>
                         <div class="col-sm-11 pl-0">
-                            <span class="text-muted muted">{{{completionstatus.string}}}</span>
+                            <span class="text-muted">{{{completionstatus.string}}}</span>
                         </div>
                     </div>
                 </div>

--- a/lib/form/templates/filetypes-browser.mustache
+++ b/lib/form/templates/filetypes-browser.mustache
@@ -89,7 +89,7 @@
             {{#selectable}}
             <input data-filetypesbrowserkey="{{key}}" type="checkbox" {{#selected}}checked{{/selected}}>
             <strong data-filetypesname="{{key}}">{{name}}</strong>
-            <small class="muted" data-filetypesextensions="{{key}}">
+            <small class="text-muted" data-filetypesextensions="{{key}}">
                 {{ext}}
             </small>
             {{/selectable}}
@@ -109,7 +109,7 @@
                 <label>
                     <input data-filetypesbrowserkey="{{key}}" type="checkbox" {{#selected}}checked{{/selected}}>
                     <span data-filetypesname="{{key}}">{{name}}</span>
-                    <small class="muted" data-filetypesextensions="{{key}}">
+                    <small class="text-muted" data-filetypesextensions="{{key}}">
                         {{ext}}
                     </small>
                 </label>

--- a/tag/templates/tagfeed.mustache
+++ b/tag/templates/tagfeed.mustache
@@ -53,7 +53,7 @@
                     </div>
                 {{/heading}}
                 {{#details}}
-                    <div class="muted">
+                    <div class="text-muted">
                         {{{details}}}
                     </div>
                 {{/details}}

--- a/theme/boost/scss/moodle/undo.scss
+++ b/theme/boost/scss/moodle/undo.scss
@@ -49,7 +49,7 @@ li.activity.label,
  * currently worked around in renderers.php function block{}
  * by rewriting the class name "invisible" to "dimmed",
  * though the blocks don't look particularly different apart
- * from their contents disappearing. Maybe try .muted? or
+ * from their contents disappearing. Maybe try .text-muted? or
  * dimming all the edit icons apart from unhide, might be a
  * nice effect, though they'd still be active. Maybe reverse
  * it to white?

--- a/theme/boost/style/moodle.css
+++ b/theme/boost/style/moodle.css
@@ -35158,7 +35158,7 @@ li.activity.label,
  * currently worked around in renderers.php function block{}
  * by rewriting the class name "invisible" to "dimmed",
  * though the blocks don't look particularly different apart
- * from their contents disappearing. Maybe try .muted? or
+ * from their contents disappearing. Maybe try .text-muted? or
  * dimming all the edit icons apart from unhide, might be a
  * nice effect, though they'd still be active. Maybe reverse
  * it to white?

--- a/theme/classic/style/moodle.css
+++ b/theme/classic/style/moodle.css
@@ -35158,7 +35158,7 @@ li.activity.label,
  * currently worked around in renderers.php function block{}
  * by rewriting the class name "invisible" to "dimmed",
  * though the blocks don't look particularly different apart
- * from their contents disappearing. Maybe try .muted? or
+ * from their contents disappearing. Maybe try .text-muted? or
  * dimming all the edit icons apart from unhide, might be a
  * nice effect, though they'd still be active. Maybe reverse
  * it to white?


### PR DESCRIPTION
Removed instances of deprecated Bootstrap2 `.muted` class.

NOTE: All other instances of "muted" that refer to audio muting are left intact.
