### PR TITLE
MDL-80188 mod_lti: prevent name claim HTML encoding

### DIFF
--- a/mod/lti/locallib.php
+++ b/mod/lti/locallib.php
@@ -871,7 +871,7 @@ function lti_build_request($instance, $typeconfig, $course, $typeid = null, $isl
     ) {
         $requestparams['lis_person_name_given'] = $USER->firstname;
         $requestparams['lis_person_name_family'] = $USER->lastname;
-        $requestparams['lis_person_name_full'] = fullname($USER);
+        $requestparams['lis_person_name_full'] = fullname($USER, true);
         $requestparams['ext_user_username'] = $USER->username;
     }
 


### PR DESCRIPTION
# [TR-5885](https://oat-sa.atlassian.net/browse/TR-5885) / [MDL-80188](https://tracker.moodle.org/browse/MDL-80188)

This PR aims to prevent HTML encoding of OIDC profile scope's name claim value.