### PR TITLE
MDL-85334 quiz: Add question type to slot deleted event.

### DIFF
--- a/mod/quiz/classes/structure.php
+++ b/mod/quiz/classes/structure.php
@@ -1064,6 +1064,10 @@ class structure {
         if (!$slot) {
             return;
         }
+
+        // Retrieves the question type associated with a given slot.
+        $qtype = $this->get_question_type_for_slot($slotnumber);
+        
         $maxslot = $DB->get_field_sql('SELECT MAX(slot) FROM {quiz_slots} WHERE quizid = ?', [$this->get_quizid()]);
 
         $trans = $DB->start_delegated_transaction();
@@ -1110,7 +1114,8 @@ class structure {
             'other' => [
                 'quizid' => $this->get_quizid(),
                 'slotnumber' => $slotnumber,
-            ]
+                'qtype' => $qtype,
+            ],
         ]);
         $event->trigger();
     }


### PR DESCRIPTION
Ensures the question type is included in the slot deleted event. This preserves critical question data before the slot record is removed, particularly useful when handling slot_deleted events where slot-related info is no longer available.

*** PLEASE DO NOT OPEN PULL REQUESTS VIA GITHUB ***

The moodle.git repository at Github is just a mirror of the official repository. We do not accept pull requests at Github.

See CONTRIBUTING.md guidelines for how to contribute patches for Moodle. Thank you.

--
