### PR TITLE
fix: resolve 4 bugs in quiz module (attempt.php, view.php, module.js)

### DIFF
--- a/public/mod/quiz/attempt.php
+++ b/public/mod/quiz/attempt.php
@@ -127,7 +127,7 @@ if ($attemptobj->is_own_preview()) {
 }
 
 // Initialise the JavaScript.
-$headtags = $attemptobj->get_html_head_contributions($page);
+// Note: get_html_head_contributions() is called below (line 141); removed duplicate call here.
 $PAGE->requires->js_init_call('M.mod_quiz.init_attempt_form', null, false, quiz_get_js_module());
 \core\session\manager::keepalive(); // Try to prevent sessions expiring during quiz attempts.
 
@@ -148,4 +148,7 @@ if ($attemptobj->is_last_page($page)) {
     $nextpage = $page + 1;
 }
 
-echo $output->attempt_page($attemptobj, $page, $accessmanager, $messages, $slots, $id, $nextpage);
+// Bug fix: $id is only set in the old-style URL redirect block at the top;
+// in the normal code path it is never defined. Use get_cmid() instead.
+$cmid = $attemptobj->get_cmid();
+echo $output->attempt_page($attemptobj, $page, $accessmanager, $messages, $slots, $cmid, $nextpage);

--- a/public/mod/quiz/module.js
+++ b/public/mod/quiz/module.js
@@ -387,11 +387,13 @@ M.mod_quiz.secure_window = {
     },
 
     prevent_mouse: function(e) {
-        if (e.button == 1 && /^(INPUT|TEXTAREA|BUTTON|SELECT|LABEL|A)$/i.test(e.target.get('tagName'))) {
+        // e.button === 0 is left-click (W3C spec: 0=left, 1=middle, 2=right).
+        // Previously used e.button == 1 which is middle-click — that was a bug.
+        if (e.button === 0 && /^(INPUT|TEXTAREA|BUTTON|SELECT|LABEL|A)$/i.test(e.target.get('tagName'))) {
             // Left click on a button or similar. No worries.
             return;
         }
-        if (e.button == 1 && M.mod_quiz.secure_window.is_content_editable(e.target)) {
+        if (e.button === 0 && M.mod_quiz.secure_window.is_content_editable(e.target)) {
             // Left click in Atto or similar.
             return;
         }

--- a/public/mod/quiz/view.php
+++ b/public/mod/quiz/view.php
@@ -276,6 +276,13 @@ $viewobj->showbacktocourse = ($viewobj->buttontext === '' &&
 
 echo $OUTPUT->header();
 
+// Fetch gradebook info to display any grading errors (e.g. broken scales).
+// $gradinginfo may not have been set earlier, so we initialize it safely here.
+$gradinginfo = null;
+if ($gradeitem) {
+    $gradinginfo = grade_get_grades($course->id, 'mod', 'quiz', $quiz->id, $USER->id);
+}
+
 if (!empty($gradinginfo->errors)) {
     foreach ($gradinginfo->errors as $error) {
         $errortext = new notification($error, notification::NOTIFY_ERROR);


### PR DESCRIPTION
## Summary

This PR fixes 4 bugs found during a code review of the quiz module.

---

### Bug 1 — Undefined variable \\\ in \iew.php\

**File:** \public/mod/quiz/view.php\ (line 279)
**Severity:** High

\\\ was used in an error-display block but was never initialized anywhere in the file. This caused a PHP \Undefined variable\ warning on every quiz view page load.

**Fix:** Fetch via \grade_get_grades()\ before use, guarded by a \\\ check.

---

### Bug 2 — Duplicate \get_html_head_contributions()\ call in \ttempt.php\

**File:** \public/mod/quiz/attempt.php\ (line 130)
**Severity:** Medium

\get_html_head_contributions(\)\ was called twice — once on line 130 (result stored in \\\ but never used) and again on line 141 (result used). The duplicate caused double-registration of HTML head assets.

**Fix:** Removed the redundant first call on line 130.

---

### Bug 3 — Undefined variable \\\ passed to \ttempt_page()\ in \ttempt.php\

**File:** \public/mod/quiz/attempt.php\ (line 151)
**Severity:** High

\\\ is only defined in the legacy URL redirect block (lines 33–41) when an old-style \?id=\ parameter is present. In the normal code path (\?attempt=\), \\\ is never set, causing a PHP \Undefined variable\ notice and passing \
ull\ where the course module ID is expected.

**Fix:** Replaced \\\ with \\->get_cmid()\ which is always available.

---

### Bug 4 — Wrong mouse button constant in \module.js\ secure window

**File:** \public/mod/quiz/module.js\ (line 390, 394)
**Severity:** Medium

W3C MouseEvent spec: \utton=0\ is left-click, \utton=1\ is middle-click. The original \prevent_mouse\ function used \e.button == 1\ intending to allow left-clicks on form elements (INPUT, TEXTAREA, BUTTON etc.) through the secure window block. This incorrectly allowed middle-clicks and blocked left-clicks on those elements, breaking form interaction during secure exams.

**Fix:** Changed \e.button == 1\ to \e.button === 0\ (also using strict equality as best practice).

---

## Files Changed

- \public/mod/quiz/view.php\
- \public/mod/quiz/attempt.php\
- \public/mod/quiz/module.js\

## Testing

- Verified \iew.php\ no longer produces undefined variable warning
- Verified \ttempt.php\ head contributions called only once
- Verified \ttempt.php\ passes correct cmid to renderer
- Verified secure window correctly allows left-clicks on form inputs