### PR TITLE
W7D5: Assessment Engine Study + UI Bug Fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,3 +37,4 @@ RUN mkdir -p /var/moodledata \
     && chown -R www-data:www-data /var/moodledata
 
 WORKDIR /var/www
+COPY php.ini /usr/local/etc/php/conf.d/moodle.ini

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+﻿FROM php:8.3-apache-bookworm
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libfreetype6-dev \
+    libjpeg62-turbo-dev \
+    libpng-dev \
+    libzip-dev \
+    libicu-dev \
+    libxml2-dev \
+    libcurl4-openssl-dev \
+    libonig-dev \
+    unzip \
+    git \
+    && docker-php-ext-configure gd --with-freetype --with-jpeg \
+    && docker-php-ext-install -j"$(nproc)" \
+        mysqli \
+        pdo_mysql \
+        gd \
+        zip \
+        intl \
+        soap \
+        opcache \
+        exif \
+        mbstring \
+        bcmath \
+    && a2enmod rewrite \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV APACHE_DOCUMENT_ROOT=/var/www/public
+
+RUN sed -ri 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' \
+    /etc/apache2/sites-available/*.conf \
+    /etc/apache2/apache2.conf \
+    /etc/apache2/conf-available/*.conf
+
+RUN mkdir -p /var/moodledata \
+    && chown -R www-data:www-data /var/moodledata
+
+WORKDIR /var/www

--- a/W7D3_PROGRESS.md
+++ b/W7D3_PROGRESS.md
@@ -1,0 +1,26 @@
+# W7D3 Progress
+
+## Task Completed
+
+- Created Moodle block plugin scaffold.
+- Created `blocks/cynaris_stats/`.
+- Added `block_cynaris_stats.php`.
+- Added `version.php`.
+- Added language file.
+- Verified the plugin structure.
+
+## Plugin
+
+`block_cynaris_stats`
+
+## Learning
+
+A Moodle block plugin is a reusable component that displays information or functionality on Moodle pages.
+
+A block plugin differs from an activity module because an activity module provides a complete learning activity, while a block provides supporting information or functionality.
+
+## Evidence
+
+Plugin scaffold created successfully under:
+
+`blocks/cynaris_stats`

--- a/blocks/cynaris_stats/README.md
+++ b/blocks/cynaris_stats/README.md
@@ -1,0 +1,11 @@
+# W7D4 Progress Dashboard
+
+The Cynaris Stats block now provides a Chart.js-based progress dashboard.
+
+## Features
+
+- Reads the current user's enrolled courses.
+- Retrieves each course's final grade.
+- Converts grades to percentages.
+- Displays course grades using a responsive bar chart.
+- Uses Moodle's built-in `core/chartjs` AMD module.

--- a/blocks/cynaris_stats/W7D5_NOTES.md
+++ b/blocks/cynaris_stats/W7D5_NOTES.md
@@ -1,0 +1,16 @@
+# W7D5 Assessment Engine Study
+
+## Assessment Engine
+
+Moodle stores assessment results through its gradebook system. Course totals can be accessed through the course grade item and the user's final grade.
+
+## UI Debugging
+
+The Cynaris Stats progress chart was improved to:
+- Maintain a suitable chart height on smaller screens.
+- Display percentage values on the Y-axis.
+- Provide an accessible label for the chart canvas.
+
+## Debugging Approach
+
+The implementation was reviewed against Moodle's existing grade APIs and Chart.js AMD module structure before committing the changes.

--- a/blocks/cynaris_stats/amd/src/dashboard.js
+++ b/blocks/cynaris_stats/amd/src/dashboard.js
@@ -7,6 +7,11 @@ define(['core/chartjs'], function(Chart) {
                 return;
             }
 
+            canvas.setAttribute(
+                'aria-label',
+                'Course grade progress chart'
+            );
+
             new Chart(canvas, {
                 type: 'bar',
                 data: {
@@ -18,10 +23,16 @@ define(['core/chartjs'], function(Chart) {
                 },
                 options: {
                     responsive: true,
+                    maintainAspectRatio: false,
                     scales: {
                         y: {
                             beginAtZero: true,
-                            max: 100
+                            max: 100,
+                            ticks: {
+                                callback: function(value) {
+                                    return value + '%';
+                                }
+                            }
                         }
                     }
                 }

--- a/blocks/cynaris_stats/amd/src/dashboard.js
+++ b/blocks/cynaris_stats/amd/src/dashboard.js
@@ -1,0 +1,31 @@
+define(['core/chartjs'], function(Chart) {
+    return {
+        init: function(chartId, labels, grades) {
+            const canvas = document.getElementById(chartId);
+
+            if (!canvas) {
+                return;
+            }
+
+            new Chart(canvas, {
+                type: 'bar',
+                data: {
+                    labels: labels,
+                    datasets: [{
+                        label: 'Grade (%)',
+                        data: grades
+                    }]
+                },
+                options: {
+                    responsive: true,
+                    scales: {
+                        y: {
+                            beginAtZero: true,
+                            max: 100
+                        }
+                    }
+                }
+            });
+        }
+    };
+});

--- a/blocks/cynaris_stats/block_cynaris_stats.php
+++ b/blocks/cynaris_stats/block_cynaris_stats.php
@@ -9,17 +9,64 @@ class block_cynaris_stats extends block_base {
     }
 
     public function get_content() {
+        global $USER, $CFG;
+
         if ($this->content !== null) {
             return $this->content;
         }
 
         $this->content = new stdClass();
 
-        $this->content->text = '
-            <p><strong>Cynaris Stats</strong></p>
-            <p>Welcome to the Cynaris Statistics Block!</p>
-            <p>This block is working correctly.</p>
-        ';
+        require_once($CFG->libdir . '/gradelib.php');
+
+        $labels = [];
+        $grades = [];
+
+        $courses = enrol_get_my_courses();
+
+        foreach ($courses as $course) {
+            if ($course->id == SITEID) {
+                continue;
+            }
+
+            $courseitem = grade_item::fetch_course_item($course->id);
+
+            if ($courseitem && !$courseitem->needsupdate) {
+                $grade = $courseitem->get_final($USER->id);
+
+                if ($grade && !is_null($grade->finalgrade) && $courseitem->grademax > 0) {
+                    $percentage = ($grade->finalgrade / $courseitem->grademax) * 100;
+
+                    $labels[] = format_string($course->fullname);
+                    $grades[] = round($percentage, 2);
+                }
+            }
+        }
+
+        $chartid = 'cynaris-stats-chart-' . uniqid();
+
+        $this->content->text = html_writer::tag(
+            'p',
+            html_writer::tag('strong', 'Cynaris Progress Dashboard')
+        );
+
+        if (empty($grades)) {
+            $this->content->text .= html_writer::tag(
+                'p',
+                'No grade data is available yet.'
+            );
+        } else {
+            $this->content->text .= html_writer::empty_tag('canvas', [
+                'id' => $chartid,
+                'height' => '250'
+            ]);
+
+            $this->page->requires->js_call_amd(
+                'block_cynaris_stats/dashboard',
+                'init',
+                [$chartid, $labels, $grades]
+            );
+        }
 
         $this->content->footer = '';
 

--- a/blocks/cynaris_stats/block_cynaris_stats.php
+++ b/blocks/cynaris_stats/block_cynaris_stats.php
@@ -58,7 +58,7 @@ class block_cynaris_stats extends block_base {
         } else {
             $this->content->text .= html_writer::empty_tag('canvas', [
                 'id' => $chartid,
-                'height' => '250'
+                'height' => '300', 'style' => 'min-height: 300px;'
             ]);
 
             $this->page->requires->js_call_amd(

--- a/blocks/cynaris_stats/block_cynaris_stats.php
+++ b/blocks/cynaris_stats/block_cynaris_stats.php
@@ -1,0 +1,28 @@
+<?php
+
+defined('MOODLE_INTERNAL') || die();
+
+class block_cynaris_stats extends block_base {
+
+    public function init() {
+        $this->title = get_string('pluginname', 'block_cynaris_stats');
+    }
+
+    public function get_content() {
+        if ($this->content !== null) {
+            return $this->content;
+        }
+
+        $this->content = new stdClass();
+
+        $this->content->text = '
+            <p><strong>Cynaris Stats</strong></p>
+            <p>Welcome to the Cynaris Statistics Block!</p>
+            <p>This block is working correctly.</p>
+        ';
+
+        $this->content->footer = '';
+
+        return $this->content;
+    }
+}

--- a/blocks/cynaris_stats/lang/en/block_cynaris_stats.php
+++ b/blocks/cynaris_stats/lang/en/block_cynaris_stats.php
@@ -1,0 +1,5 @@
+<?php
+
+$string['pluginname'] = 'Cynaris Stats';
+$string['cynaris_stats:addinstance'] = 'Add a new Cynaris Stats block';
+$string['cynaris_stats:myaddinstance'] = 'Add a new Cynaris Stats block to Dashboard';

--- a/blocks/cynaris_stats/version.php
+++ b/blocks/cynaris_stats/version.php
@@ -1,0 +1,9 @@
+<?php
+
+defined('MOODLE_INTERNAL') || die();
+
+$plugin->component = 'block_cynaris_stats';
+$plugin->version = 2026082500;
+$plugin->requires = 2022041900;
+$plugin->maturity = MATURITY_ALPHA;
+$plugin->release = '0.1';

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,28 @@
+﻿services:
+  db:
+    image: mariadb:10.11
+    container_name: moodle-db
+    restart: unless-stopped
+    environment:
+      MARIADB_ROOT_PASSWORD: rootpassword
+      MARIADB_DATABASE: moodle
+      MARIADB_USER: moodle
+      MARIADB_PASSWORD: moodlepassword
+    volumes:
+      - moodle-db-data:/var/lib/mysql
+
+  moodle:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: moodle-web
+    restart: unless-stopped
+    ports:
+      - "8080:80"
+    volumes:
+      - ./:/var/www
+    depends_on:
+      - db
+
+volumes:
+  moodle-db-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
-﻿services:
+services:
   db:
-    image: mariadb:10.11
+    image: mariadb:11.4
     container_name: moodle-db
     restart: unless-stopped
     environment:
@@ -21,8 +21,10 @@
       - "8080:80"
     volumes:
       - ./:/var/www
+      - moodle-data:/var/moodledata
     depends_on:
       - db
 
 volumes:
   moodle-db-data:
+  moodle-data:

--- a/php.ini
+++ b/php.ini
@@ -1,0 +1,1 @@
+max_input_vars = 5000


### PR DESCRIPTION
## W7D5: Assessment Engine Study + UI Bug Fix

### Changes Made
- Improved the Cynaris Stats progress dashboard UI.
- Updated the chart height for better visibility.
- Continued using Moodle's built-in `core/chartjs` AMD module.
- Reviewed Moodle's assessment and grading engine.
- Used course grade items and final grades to calculate progress percentages.
- Added W7D5 assessment notes.

### Testing
- `git diff --check` passed.
- Working tree is clean.
- Branch rebased successfully on `upstream/main`.
- Changes pushed successfully to origin.

### Commits
- fix: improve progress dashboard chart UI
- docs: add W7D5 assessment notes

### CIA Review
- Reviewed the implementation and Moodle grading flow before committing.